### PR TITLE
Update bottom bar unit selection position

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@
     <div id="bottomBar" class="relative p-1 flex justify-center items-center z-100" style="height:40px;background-color:#BABCBB;">
 
         <!-- Поле выбора пары единиц -->
-        <select id="unitPairsSelect" style="position:absolute; left:calc(50% - 70px);">
+        <select id="unitPairsSelect" style="position:absolute; left:calc(50% + 10px);">
             <option value="none">Польз.</option>
             <option value="metric_t_m">т, м</option>
             <option value="metric_standard">кН, м</option>
@@ -257,7 +257,7 @@
         </select>
 
         <!-- Остальные элементы -->
-        <div class="flex items-center" style="margin-left:calc(50% + 10px);">
+        <div class="flex items-center" style="margin-left:calc(50% + 80px);">
             <select id="forceUnitsSelect" style="margin-right:5px;">
                 <option value="N">Н</option>
                 <option value="kN">кН</option>


### PR DESCRIPTION
## Summary
- move the unit pair selector to the right side of the bottom bar center with a 10px offset
- shift the remaining unit controls so they don't overlap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b3024752c832c9a0f7349b665bf26