### PR TITLE
Align bottom panel controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,22 +243,23 @@
     </div>
 
     <!-- Нижняя панель управления -->
-    <div id="bottomBar" class="relative p-1 flex justify-center items-center z-100" style="height:40px;background-color:#BABCBB;">
+    <div id="bottomBar" class="relative p-1 flex items-center justify-center z-100" style="height:40px;background-color:#BABCBB;">
 
-        <!-- Поле выбора пары единиц -->
-        <select id="unitPairsSelect" style="position:absolute; left:calc(50% + 10px);">
-            <option value="none">Польз.</option>
-            <option value="metric_t_m">т, м</option>
-            <option value="metric_standard">кН, м</option>
-            <option value="metric_mm_N">Н, мм</option>
-            <option value="imperial_ft_lbf">lbf, фут</option>
-            <option value="imperial_in_lbf">lbf, дюйм</option>
-            <option value="imperial_in_kips">kips, дюйм</option>
-        </select>
+        <!-- Контейнер элементов, начинающийся от центра панели -->
+        <div id="bottomBarContent" class="flex items-center" style="position:absolute; left:calc(50% + 10px);">
+            <!-- Поле выбора пары единиц -->
+            <select id="unitPairsSelect">
+                <option value="none">Польз.</option>
+                <option value="metric_t_m">т, м</option>
+                <option value="metric_standard">кН, м</option>
+                <option value="metric_mm_N">Н, мм</option>
+                <option value="imperial_ft_lbf">lbf, фут</option>
+                <option value="imperial_in_lbf">lbf, дюйм</option>
+                <option value="imperial_in_kips">kips, дюйм</option>
+            </select>
 
-        <!-- Остальные элементы -->
-        <div class="flex items-center" style="margin-left:calc(50% + 80px);">
-            <select id="forceUnitsSelect" style="margin-right:5px;">
+            <!-- Остальные элементы -->
+            <select id="forceUnitsSelect">
                 <option value="N">Н</option>
                 <option value="kN">кН</option>
                 <option value="lbf">фунт-сила</option>
@@ -266,19 +267,19 @@
                 <option value="t">т</option>
                 <option value="kips">kips</option>
             </select>
-            <select id="unitsSelect" style="margin-right:10px;">
+            <select id="unitsSelect">
                 <option value="m">м</option>
                 <option value="cm">см</option>
                 <option value="mm">мм</option>
                 <option value="in">дюймы</option>
                 <option value="ft">фут</option>
             </select>
-            <svg width="1" height="25" style="margin-right:10px;">
+            <svg width="1" height="25">
                 <line x1="0" y1="0" x2="0" y2="25" stroke="black" stroke-width="1" stroke-linecap="round" />
             </svg>
-            <label for="divisions" style="margin-right:5px;">Делений на ед.:</label>
-            <input type="number" id="divisions" value="4" min="1" max="20" style="margin-right:10px;">
-            <label for="snapToGrid" style="margin-right:5px;">Привязка к сетке</label>
+            <label for="divisions">Делений на ед.:</label>
+            <input type="number" id="divisions" value="4" min="1" max="20">
+            <label for="snapToGrid">Привязка к сетке</label>
             <input type="checkbox" id="snapToGrid">
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -251,6 +251,13 @@
         #bottomBar #clearCanvasBtn { background-color: #dc3545; border-color: #dc3545;}
         #bottomBar #clearCanvasBtn:hover { background-color: #c82333; border-color: #bd2130;}
 
+        /* Контейнер элементов нижней панели */
+        #bottomBarContent {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
 
         /* Стили для тултипа и контекстного меню */
         .tooltip {


### PR DESCRIPTION
## Summary
- align bottom bar controls from center
- ensure 10px spacing between bottom bar items with flex gap

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_688b34d2b3d8832ca644a0b1f602816d