### PR TITLE
Style bottom panel dropdown and checkbox

### DIFF
--- a/style.css
+++ b/style.css
@@ -226,19 +226,39 @@
         }
 
         #bottomBar select {
+            padding: 7px;
+            border-radius: 10px;
+            box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
             appearance: none;
             -moz-appearance: none;
             -webkit-appearance: none;
             background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 6'><path d='M0 0 L4 6 L8 0 Z' fill='%23529774'/></svg>");
             background-repeat: no-repeat;
-            background-position: right 2px center;
+            background-position: right 10px center;
             background-size: 8px 6px;
         }
 
         #bottomBar input[type="checkbox"] {
-            width: 15px;
-            height: 15px;
+            appearance: none;
+            -webkit-appearance: none;
+            width: 18px;
+            height: 18px;
             margin-right: 3px;
+            border: 0.5px solid #000000;
+            background-color: #FFFFFF;
+            position: relative;
+        }
+
+        #bottomBar input[type="checkbox"]:checked::before {
+            content: "";
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 9px;
+            height: 9px;
+            background-color: #529774;
+            border-radius: 50%;
+            transform: translate(-50%, -50%);
         }
 
         #bottomBar button { 


### PR DESCRIPTION
## Summary
- style dropdown select with padding, radius and drop-shadow
- customize bottom panel checkbox with a colored dot indicator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b3c259058832ca957eb0fcebea5d7