### PR TITLE
Update unit selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,30 +249,31 @@
         <div id="bottomBarContent" class="flex items-center" style="position:absolute; left:calc(50% + 10px);">
             <!-- Поле выбора пары единиц -->
             <select id="unitPairsSelect">
-                <option value="none">Польз.</option>
-                <option value="metric_t_m">т, м</option>
-                <option value="metric_standard">кН, м</option>
-                <option value="metric_mm_N">Н, мм</option>
-                <option value="imperial_ft_lbf">lbf, фут</option>
-                <option value="imperial_in_lbf">lbf, дюйм</option>
-                <option value="imperial_in_kips">kips, дюйм</option>
+                <option value="none">Custom</option>
+                <option value="metric_kg_m">kg, m</option>
+                <option value="metric_t_m">t, m</option>
+                <option value="metric_mm_N">N, mm</option>
+                <option value="metric_standard">kN, m</option>
+                <option value="imperial_ft_lbf">lbf, ft</option>
+                <option value="imperial_in_lbf">lbf, in</option>
+                <option value="imperial_in_kips">kips, in</option>
             </select>
 
             <!-- Остальные элементы -->
             <select id="forceUnitsSelect">
-                <option value="N">Н</option>
-                <option value="kN">кН</option>
-                <option value="lbf">фунт-сила</option>
-                <option value="kg">кг</option>
-                <option value="t">т</option>
+                <option value="kg">kg</option>
+                <option value="t">t</option>
+                <option value="N">N</option>
+                <option value="kN">kN</option>
+                <option value="lbf">lbf</option>
                 <option value="kips">kips</option>
             </select>
             <select id="unitsSelect">
-                <option value="m">м</option>
-                <option value="cm">см</option>
-                <option value="mm">мм</option>
-                <option value="in">дюймы</option>
-                <option value="ft">фут</option>
+                <option value="mm">mm</option>
+                <option value="cm">cm</option>
+                <option value="m">m</option>
+                <option value="in">in</option>
+                <option value="ft">ft</option>
             </select>
             <svg width="1" height="25">
                 <line x1="0" y1="0" x2="0" y2="25" stroke="black" stroke-width="1" stroke-linecap="round" />

--- a/js/main.js
+++ b/js/main.js
@@ -126,9 +126,11 @@
             resizeCanvas();
             addEventListeners();
             
-            forceUnitsSelect.value = 'kN'; 
+            forceUnitsSelect.value = 'kN';
             forceUnitsSelect.dataset.previousValue = 'kN';
-            
+            unitsSelect.value = 'm';
+            unitsSelect.dispatchEvent(new Event('change'));
+
             currentUnit = unitsSelect.value;
             currentForceUnit = forceUnitsSelect.value;
             

--- a/js/state.js
+++ b/js/state.js
@@ -77,8 +77,9 @@
             'metric_mm_N': { length: 'mm', force: 'N' },
             'imperial_ft_lbf': { length: 'ft', force: 'lbf' },
             'imperial_in_lbf': { length: 'in', force: 'lbf' },
-			'imperial_in_kips': { length: 'in', force: 'kips' },
-			'metric_t_m': { length: 'm', force: 't' }
+            'imperial_in_kips': { length: 'in', force: 'kips' },
+            'metric_kg_m': { length: 'm', force: 'kg' },
+            'metric_t_m': { length: 'm', force: 't' }
         };
 		
 		let currentUnitPair = unitPairsSelect.value;


### PR DESCRIPTION
## Summary
- reorder and translate bottom bar unit dropdowns to English
- add new `kg, m` preset
- set default length unit to `m`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b4a387ee4832c90d816f01b6fc691