### PR TITLE
Fix grid scaling due to unit initialization

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -128,11 +128,11 @@
             
             forceUnitsSelect.value = 'kN';
             forceUnitsSelect.dataset.previousValue = 'kN';
-            unitsSelect.value = 'm';
-            unitsSelect.dispatchEvent(new Event('change'));
 
+            unitsSelect.value = 'm';
             currentUnit = unitsSelect.value;
             currentForceUnit = forceUnitsSelect.value;
+            unitsSelect.dispatchEvent(new Event('change'));
             
             updateUnitPairsSelect(); 
             updateForceUnitDisplay(); 


### PR DESCRIPTION
## Summary
- set `currentUnit` before triggering unit change event during initialization
- prevents massive scale jump so grid and axis numbers render properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b4cc1fd74832caad0d33453ee6e87