### PR TITLE
Refine left floating panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
     <div class="floating-panel left">
         <img src="images/logo_RodX.png" alt="RodX logo" class="left-panel-logo">
         <div class="left-panel-separator"></div>
-        <input type="text" class="left-panel-input">
+        <input type="text" class="left-panel-input" placeholder="Project title">
+        <div class="left-panel-separator"></div>
     </div>
     <div class="floating-panel center">Панель в центре</div>
     <div class="floating-panel right">Панель справа</div>

--- a/style.css
+++ b/style.css
@@ -365,7 +365,7 @@
     font-weight: 300;
     font-size: 16px;
     box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.25);
-    padding: 10px;
+    padding: 5px;
     box-sizing: border-box;
     height: 50px;
     display: flex;
@@ -392,10 +392,11 @@
 }
 
 .left-panel-separator {
-    margin-left: 20px;
+    margin-left: 10px;
+    margin-right: 10px;
     width: 1px;
-    height: 35px;
-    background-color: #000;
+    height: 100%;
+    background-color: #BABCBB;
 }
 
 .left-panel-input {


### PR DESCRIPTION
## Summary
- Shrink floating-panel padding to 5px and allow logo to expand
- Add placeholder and symmetrical separators to left panel
- Style separators with neutral gray #BABCBB

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ccd0212e4832c969e48871f226004