### PR TITLE
Add menus to center floating toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,31 @@
             <span class="menu-title">Share</span>
         </div>
     </div>
-    <div class="floating-panel center">Панель в центре</div>
+    <div class="floating-panel center">
+        <div class="file-menu">
+            <span class="menu-title">Properties</span>
+            <div class="dropdown-menu">
+                <div id="materialsMenuItem">Materials</div>
+                <div id="sectionsMenuItem">Sections</div>
+            </div>
+        </div>
+        <div class="left-panel-separator"></div>
+        <div id="selectAllMenu" class="share-menu">
+            <span class="menu-title">Select All</span>
+        </div>
+        <div id="clearAllMenu" class="share-menu">
+            <span class="menu-title">Clear All</span>
+        </div>
+        <div class="left-panel-separator"></div>
+        <div class="file-menu">
+            <span class="menu-title">Visibility</span>
+            <div class="dropdown-menu">
+                <div id="visibilityNodesMenuItem">Nodes</div>
+                <div id="visibilityElementsMenuItem">Elements</div>
+                <div id="visibilitySectionsMenuItem">Sections</div>
+            </div>
+        </div>
+    </div>
     <div class="floating-panel right">Панель справа</div>
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -3433,6 +3433,15 @@ let sectionDetailsContent;
             const toggleLineNumbersBtn = document.getElementById("toggleLineNumbersBtn");
             const toggleBetaAngleIconsBtn = document.getElementById("toggleBetaAngleIconsBtn");
             const selectAllBtn = document.getElementById('selectAllBtn');
+            const clearCanvasBtnTop = document.getElementById('clearCanvasBtn');
+
+            const materialsMenuItem = document.getElementById('materialsMenuItem');
+            const sectionsMenuItem = document.getElementById('sectionsMenuItem');
+            const selectAllMenu = document.getElementById('selectAllMenu');
+            const clearAllMenu = document.getElementById('clearAllMenu');
+            const visibilityNodesMenuItem = document.getElementById('visibilityNodesMenuItem');
+            const visibilityElementsMenuItem = document.getElementById('visibilityElementsMenuItem');
+            const visibilitySectionsMenuItem = document.getElementById('visibilitySectionsMenuItem');
 			
 			// Получаем ссылки на новые DOM-элементы
             const addMaterialToModelBtn = document.getElementById('addMaterialToModelBtn');
@@ -3497,6 +3506,28 @@ let sectionDetailsContent;
             }
             if (selectAllBtn) {
                 selectAllBtn.addEventListener('click', selectAllElements);
+            }
+
+            if (materialsMenuItem) {
+                materialsMenuItem.addEventListener('click', () => openMaterialsModalBtn && openMaterialsModalBtn.click());
+            }
+            if (sectionsMenuItem) {
+                sectionsMenuItem.addEventListener('click', () => openSectionsModalBtn && openSectionsModalBtn.click());
+            }
+            if (selectAllMenu) {
+                selectAllMenu.addEventListener('click', () => selectAllBtn && selectAllBtn.click());
+            }
+            if (clearAllMenu) {
+                clearAllMenu.addEventListener('click', () => clearCanvasBtnTop && clearCanvasBtnTop.click());
+            }
+            if (visibilityNodesMenuItem) {
+                visibilityNodesMenuItem.addEventListener('click', () => toggleNodeNumbersBtn && toggleNodeNumbersBtn.click());
+            }
+            if (visibilityElementsMenuItem) {
+                visibilityElementsMenuItem.addEventListener('click', () => toggleLineNumbersBtn && toggleLineNumbersBtn.click());
+            }
+            if (visibilitySectionsMenuItem) {
+                visibilitySectionsMenuItem.addEventListener('click', () => toggleBetaAngleIconsBtn && toggleBetaAngleIconsBtn.click());
             }
             
             // Вам потребуется кнопка для сохранения нового материала. 


### PR DESCRIPTION
## Summary
- Add properties, selection, and visibility menus to the center floating panel
- Hook dropdown items to existing material/section dialogs, selection commands, and visibility toggles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dabe4f998832c89d1f40bdc623045