### PR TITLE
Refine right panel and account menu hover area

### DIFF
--- a/style.css
+++ b/style.css
@@ -386,7 +386,7 @@
     transform: translateX(-50%);
 }
 .floating-panel.right {
-    width: 220px;
+    width: 180px;
     right: 10px;
 }
 
@@ -574,10 +574,10 @@
     content: '';
     position: absolute;
     top: 100%;
-    left: 0;
+    right: 0;
     width: 100%;
     height: 10px;
-    
+    background-color: transparent;
 }
 
 


### PR DESCRIPTION
## Summary
- Shorten right floating panel by 40px
- Add transparent hover buffer below account logo dropdown

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dc82a6bbc832c93586e0724980991