### PR TITLE
Hide crosshair tooltip when hovering elements

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3239,6 +3239,10 @@
         }
 
         function updateCursorTooltip() {
+            if (hoveredElement && !isPanning && customContextMenu.classList.contains('hidden')) {
+                cursorTooltip.classList.add('hidden');
+                return;
+            }
             const rect = canvas.getBoundingClientRect();
             const offsetX = 15;
             const offsetY = 15;


### PR DESCRIPTION
## Summary
- Hide cursor coordinate tooltip when hovering an existing node or line
- Preserve tooltips for node coordinates and element length

## Testing
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_688f4bec1a88832c817adb20f917fa8a