### PR TITLE
Add confirmation modal for clearing model

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,6 +270,16 @@
         </div>
     </div>
 
+    <div id="clearAllModal" class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center hidden z-50">
+        <div class="clear-modal-content">
+            <p>All elements, nodes, loads, and supports will be deleted from the model. Materials and sections will not be deleted.</p>
+            <div class="modal-buttons">
+                <button id="cancelClearAll" class="modal-button">Cancel</button>
+                <button id="confirmClearAll" class="modal-button">Confirm</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Нижняя панель управления -->
     <div id="bottomBar" class="relative p-1 flex items-center justify-center z-100" style="height:33px;background-color:#BABCBB;">
 

--- a/js/main.js
+++ b/js/main.js
@@ -3485,6 +3485,9 @@ let sectionsModal;
             const visibilityNodesMenuItem = document.getElementById('visibilityNodesMenuItem');
             const visibilityElementsMenuItem = document.getElementById('visibilityElementsMenuItem');
             const visibilitySectionsMenuItem = document.getElementById('visibilitySectionsMenuItem');
+            const clearAllModal = document.getElementById('clearAllModal');
+            const confirmClearAll = document.getElementById('confirmClearAll');
+            const cancelClearAll = document.getElementById('cancelClearAll');
 			
 			// Получаем ссылки на новые DOM-элементы
             const addMaterialToModelBtn = document.getElementById('addMaterialToModelBtn');
@@ -3556,8 +3559,28 @@ let sectionsModal;
             if (selectAllMenu) {
                 selectAllMenu.addEventListener('click', selectAllElements);
             }
-            if (clearAllMenu) {
-                clearAllMenu.addEventListener('click', clearAll);
+            if (clearAllMenu && clearAllModal) {
+                clearAllMenu.addEventListener('click', () => {
+                    clearAllModal.classList.remove('hidden');
+                });
+            }
+            if (cancelClearAll && clearAllModal) {
+                cancelClearAll.addEventListener('click', () => {
+                    clearAllModal.classList.add('hidden');
+                });
+            }
+            if (confirmClearAll && clearAllModal) {
+                confirmClearAll.addEventListener('click', () => {
+                    clearAll();
+                    clearAllModal.classList.add('hidden');
+                });
+            }
+            if (clearAllModal) {
+                clearAllModal.addEventListener('click', (e) => {
+                    if (e.target === clearAllModal) {
+                        clearAllModal.classList.add('hidden');
+                    }
+                });
             }
             if (visibilityNodesMenuItem) {
                 visibilityNodesMenuItem.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -355,6 +355,49 @@
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
 
+        #clearAllModal {
+            position: fixed;
+            inset: 0;
+            background-color: rgba(0, 0, 0, 0.6);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 50;
+        }
+        #clearAllModal > .clear-modal-content {
+            background-color: #FFFFFF;
+            border-radius: 10px;
+            box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.25);
+            font-family: 'Roboto', sans-serif;
+            font-weight: 300;
+            font-size: 14px;
+            padding: 20px;
+            text-align: center;
+        }
+        #clearAllModal .modal-buttons {
+            margin-top: 20px;
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
+        #clearAllModal .modal-button {
+            width: 64px;
+            height: 22px;
+            border-radius: 10px;
+            background-color: #BABCBB;
+            color: #000000;
+            border: none;
+            cursor: pointer;
+        }
+        #clearAllModal .modal-button:hover {
+            border: 0.3px solid #000000;
+        }
+        #clearAllModal .modal-button:active {
+            background-color: #E1F6EF;
+            color: #529774;
+            border: 0.3px solid #529774;
+        }
+
 
 .floating-panel {
     position: fixed;


### PR DESCRIPTION
## Summary
- show confirmation modal when Clear All menu selected
- style modal and buttons to match floating menus
- hook Confirm/Cancel buttons to clear and close

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f55c274d0832cbf036bf9b684a137