### PR TITLE
fix(clear-all): add confirmation modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,7 @@
 
     <div id="clearAllModal" class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center hidden z-50">
         <div class="clear-modal-content">
+            <button id="closeClearAllModal" class="modal-close">&times;</button>
             <p>
                 All elements, nodes, loads, and supports will be deleted from the model.<br>
                 Materials and sections will not be deleted.

--- a/js/main.js
+++ b/js/main.js
@@ -1149,10 +1149,6 @@
                 mouse.snappedY = snapped.y; 
                 draw();
             });
-            if (clearCanvasBtn) {
-                clearCanvasBtn.addEventListener('click', clearAll);
-            }
-
             // НОВОЕ: Обработчик для кнопки сохранения модели
             if (saveModelBtn) {
                 saveModelBtn.addEventListener('click', saveModel);
@@ -3488,6 +3484,7 @@ let sectionsModal;
             const clearAllModal = document.getElementById('clearAllModal');
             const confirmClearAll = document.getElementById('confirmClearAll');
             const cancelClearAll = document.getElementById('cancelClearAll');
+            const closeClearAllModal = document.getElementById('closeClearAllModal');
 			
 			// Получаем ссылки на новые DOM-элементы
             const addMaterialToModelBtn = document.getElementById('addMaterialToModelBtn');
@@ -3564,6 +3561,11 @@ let sectionsModal;
                     clearAllModal.classList.remove('hidden');
                 });
             }
+            if (clearCanvasBtn && clearAllModal) {
+                clearCanvasBtn.addEventListener('click', () => {
+                    clearAllModal.classList.remove('hidden');
+                });
+            }
             if (cancelClearAll && clearAllModal) {
                 cancelClearAll.addEventListener('click', () => {
                     clearAllModal.classList.add('hidden');
@@ -3572,6 +3574,11 @@ let sectionsModal;
             if (confirmClearAll && clearAllModal) {
                 confirmClearAll.addEventListener('click', () => {
                     clearAll();
+                    clearAllModal.classList.add('hidden');
+                });
+            }
+            if (closeClearAllModal && clearAllModal) {
+                closeClearAllModal.addEventListener('click', () => {
                     clearAllModal.classList.add('hidden');
                 });
             }

--- a/style.css
+++ b/style.css
@@ -359,12 +359,13 @@
             position: fixed;
             inset: 0;
             background-color: rgba(0, 0, 0, 0.6);
-            display: flex;
+            /* display removed to allow Tailwind's hidden class */
             align-items: center;
             justify-content: center;
             z-index: 50;
         }
         #clearAllModal > .clear-modal-content {
+            position: relative;
             background-color: #FFFFFF;
             border-radius: 10px;
             box-shadow: 3px 3px 6px rgba(0, 0, 0, 0.25);
@@ -374,6 +375,15 @@
             padding: 20px;
             text-align: center;
             width: 250px;
+        }
+        #clearAllModal .modal-close {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            background: none;
+            border: none;
+            font-size: 16px;
+            cursor: pointer;
         }
         #clearAllModal .modal-buttons {
             margin-top: 20px;


### PR DESCRIPTION
## Summary
- prevent clear-all warning modal from showing on load
- show warning modal when using Clear All controls
- add close icon for modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5b7c9634832caaf4318e92fa0d21