### PR TITLE
Refine node property panel layout

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1743,26 +1743,32 @@
                 nodePropertiesContent.innerHTML = `
                     <h4 class="text-gray-700 mb-2">Node properties ${selectedNode.node_id}</h4>
                     <div class="property-group">
-                        <label for="nodeX">X:</label>
-                        <input type="number" id="nodeX" value="${selectedNode.x.toFixed(2)}">
-                        <label for="nodeY">Y:</label>
-                        <input type="number" id="nodeY" value="${selectedNode.y.toFixed(2)}">
+                        <div class="coordinates-row">
+                            <label for="nodeX">X:</label>
+                            <input type="number" id="nodeX" value="${selectedNode.x.toFixed(2)}">
+                            <label for="nodeY">Y:</label>
+                            <input type="number" id="nodeY" value="${selectedNode.y.toFixed(2)}">
+                        </div>
                     </div>
                     <div class="property-group">
                         <h4 class="text-gray-700 mb-2">Boundaries</h4>
-                        <div id="restrictionIconsContainer" class="flex flex-wrap gap-2 mb-4">
+                        <div class="restriction-grid">
+                            <div id="restrictionIconsCol1" class="restriction-icons-col"></div>
+                            <div id="restrictionIconsCol2" class="restriction-icons-col"></div>
+                            <div class="restriction-checkboxes-col">
+                                <div class="checkbox-group">
+                                    <input type="checkbox" id="restrictX" ${currentRestriction.dx === 1 ? 'checked' : ''}>
+                                    <label for="restrictX">dx</label>
+                                </div>
+                                <div class="checkbox-group">
+                                    <input type="checkbox" id="restrictY" ${currentRestriction.dy === 1 ? 'checked' : ''}>
+                                    <label for="restrictY">dy</label>
+                                </div>
+                                <div class="checkbox-group">
+                                    <input type="checkbox" id="restrictR" ${currentRestriction.dr === 1 ? 'checked' : ''}>
+                                    <label for="restrictR">dr</label>
+                                </div>
                             </div>
-                        <div class="checkbox-group">
-                            <input type="checkbox" id="restrictX" ${currentRestriction.dx === 1 ? 'checked' : ''}>
-                            <label for="restrictX">dx</label>
-                        </div>
-                        <div class="checkbox-group">
-                            <input type="checkbox" id="restrictY" ${currentRestriction.dy === 1 ? 'checked' : ''}>
-                            <label for="restrictY">dy</label>
-                        </div>
-                        <div class="checkbox-group">
-                            <input type="checkbox" id="restrictR" ${currentRestriction.dr === 1 ? 'checked' : ''}>
-                            <label for="restrictR">dr</label>
                         </div>
                     </div>
                     <div class="property-group">
@@ -1796,7 +1802,8 @@
                 const restrictXCheckbox = document.getElementById('restrictX');
                 const restrictYCheckbox = document.getElementById('restrictY');
                 const restrictRCheckbox = document.getElementById('restrictR');
-                const restrictionIconsContainer = document.getElementById('restrictionIconsContainer');
+                const restrictionIconsCol1 = document.getElementById('restrictionIconsCol1');
+                const restrictionIconsCol2 = document.getElementById('restrictionIconsCol2');
 
                 const nodeLoadsList = document.getElementById('nodeLoadsList');
                 const addForceXInput = document.getElementById('addForceX');
@@ -1857,12 +1864,15 @@
                 restrictRCheckbox.addEventListener('change', updateRestriction);
 
                 const renderRestrictionIcons = () => {
-                    restrictionIconsContainer.innerHTML = '';
+                    restrictionIconsCol1.innerHTML = '';
+                    restrictionIconsCol2.innerHTML = '';
 
                     currentRestriction = restrictions.find(r => r.node_id === selectedNode.node_id);
                     if (!currentRestriction) {
                         currentRestriction = { dx: 0, dy: 0, dr: 0, type: "none" };
                     }
+
+                    const buttons = [];
 
                     const noRestrictionBtn = document.createElement('button');
                     noRestrictionBtn.className = `restriction-icon-btn ${currentRestriction.dx === 0 && currentRestriction.dy === 0 && currentRestriction.dr === 0 ? 'active' : ''}`;
@@ -1875,7 +1885,7 @@
                         restrictRCheckbox.checked = false;
                         updateRestriction();
                     });
-                    restrictionIconsContainer.appendChild(noRestrictionBtn);
+                    buttons.push(noRestrictionBtn);
 
                     for (const typeKey in restrictionTypes) {
                         const type = restrictionTypes[typeKey];
@@ -1897,9 +1907,12 @@
                                 restrictRCheckbox.checked = type.dr === 1;
                                 updateRestriction();
                             });
-                            restrictionIconsContainer.appendChild(btn);
+                            buttons.push(btn);
                         }
                     }
+
+                    buttons.slice(0, 4).forEach(btn => restrictionIconsCol1.appendChild(btn));
+                    buttons.slice(4).forEach(btn => restrictionIconsCol2.appendChild(btn));
                 };
 
                 renderRestrictionIcons();
@@ -1911,12 +1924,12 @@
                     if (loadsForSelectedNode.length === 0) {
                         nodeLoadsList.innerHTML = '<p class="text-gray-500 text-xs font-light">No loads yet</p>';
                     } else {
-                        const currentForceDisplayUnit = forceUnitsSelect.value; 
+                        const currentForceDisplayUnit = forceUnitsSelect.value;
                         const currentLengthDisplayUnit = unitsSelect.value;
                         const currentMomentDisplayUnit = currentForceDisplayUnit + '*' + currentLengthDisplayUnit;
 
                         nodeLoadsList.innerHTML = '';
-                        nodeSpecificLoads.forEach(load => { 
+                        loadsForSelectedNode.forEach(load => {
                             let displayedValue;
                             let displayedUnitString;
 

--- a/style.css
+++ b/style.css
@@ -104,6 +104,19 @@
             box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
             border-color: #000;
         }
+
+        .coordinates-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .coordinates-row label {
+            display: inline-block;
+            margin-bottom: 0;
+        }
+        .coordinates-row input[type="number"] {
+            margin-bottom: 0;
+        }
         .property-group .checkbox-group {
             display: flex;
             align-items: center;
@@ -182,17 +195,21 @@
             border: 0.3px solid #529774;
         }
 
+        .properties-panel button.restriction-icon-btn {
+            width: 40px;
+            height: 40px;
+            border-radius: 5px;
+            padding: 5px;
+            box-sizing: border-box;
+        }
+
         .restriction-icon-btn {
             background-color: #e2e8f0;
             border: 1px solid #cbd5e0;
-            border-radius: 6px;
-            padding: 5px;
             cursor: pointer;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 33px;
-            height: 33px;
             transition: all 0.2s ease-in-out;
             margin: 4px;
         }
@@ -214,6 +231,21 @@
             font-size: 2em; /* Размер символа "Ø" */
             font-weight: bold;
             color: #666;
+        }
+
+        .restriction-grid {
+            display: grid;
+            grid-template-columns: repeat(3, max-content);
+            gap: 10px;
+            align-items: start;
+        }
+        .restriction-icons-col {
+            display: flex;
+            flex-direction: column;
+        }
+        .restriction-checkboxes-col {
+            display: flex;
+            flex-direction: column;
         }
 		
         .visibility-toggle-btn {


### PR DESCRIPTION
## Summary
- display node X/Y inputs in a single row
- arrange fixation controls into two button columns and a checkbox column
- style fixation buttons as 40px squares with 5px radius

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891aad51b2c832cb2e3dd80cd296982