### PR TITLE
Adjust model tree appearance and support counts

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -220,23 +220,20 @@
             const sectionsChildren = modelSections.map((sec, index) => `${index + 1}: ${sec.name}`);
             addSection('sections', `Sections: ${modelSections.length}`, sectionsChildren, modelSections.length > 0);
 
-            const supportCounts = {
-                fixed: restrictions.filter(r => r.type === 'fixed').length,
-                pinned: restrictions.filter(r => r.type === 'pinned').length,
-                'rolled-x': restrictions.filter(r => r.type === 'rolled-x').length,
-                'rolled-y': restrictions.filter(r => r.type === 'rolled-y').length,
-                'sleeve-x': restrictions.filter(r => r.type === 'sleeve-x').length,
-                'sleeve-y': restrictions.filter(r => r.type === 'sleeve-y').length
-            };
-            const supportsTotal = Object.values(supportCounts).reduce((a, b) => a + b, 0);
-            const supportsChildren = [
-                `Fixed: ${supportCounts.fixed}`,
-                `Pinned: ${supportCounts.pinned}`,
-                `Roller-X: ${supportCounts['rolled-x']}`,
-                `Roller-Y: ${supportCounts['rolled-y']}`,
-                `Sliding-X: ${supportCounts['sleeve-x']}`,
-                `Sliding-Y: ${supportCounts['sleeve-y']}`
+            const supportTypes = [
+                { name: 'Fixed', dx: 1, dy: 1, dr: 1 },
+                { name: 'Pinned', dx: 1, dy: 1, dr: 0 },
+                { name: 'Roller-X', dx: 0, dy: 1, dr: 0 },
+                { name: 'Roller-Y', dx: 1, dy: 0, dr: 0 },
+                { name: 'Slider-X', dx: 0, dy: 1, dr: 1 },
+                { name: 'Slider-Y', dx: 1, dy: 0, dr: 1 }
             ];
+            const supportCounts = {};
+            supportTypes.forEach(type => {
+                supportCounts[type.name] = restrictions.filter(r => r.dx === type.dx && r.dy === type.dy && r.dr === type.dr).length;
+            });
+            const supportsTotal = Object.values(supportCounts).reduce((a, b) => a + b, 0);
+            const supportsChildren = supportTypes.map(type => `${type.name}: ${supportCounts[type.name]}`);
             addSection('supports', `Supports: ${supportsTotal}`, supportsChildren, supportsTotal > 0);
 
             const pointLoads = nodeLoads.filter(l => l.type === 'point_force').length;

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@
             left: 10px;
             bottom: calc(43px + 300px + 10px);
             width: 300px;
-            background-color: #f0f2f5;
+            background-color: #ffffff;
             padding: 15px;
             box-sizing: border-box;
             overflow-y: auto;
@@ -69,6 +69,9 @@
             list-style: none;
             padding-left: 15px;
             margin: 0;
+        }
+        .model-tree-panel ul ul {
+            padding-left: 0;
         }
         .tree-item {
             cursor: pointer;


### PR DESCRIPTION
## Summary
- set model tree panel background to white
- reduce child node indent and align model tree entries
- compute support counts by dx/dy/dr mapping and display as Fixed, Pinned, Roller-X/Y, Slider-X/Y

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c8ceb368832ca7bdad3e6c09018c