### PR TITLE
refactor: adjust material manager layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,79 +95,81 @@
 
     <!-- Модальное окно для материалов -->
     <div id="materialsModal" class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="modal-content bg-white p-8 rounded-lg shadow-xl overflow-y-auto">
+        <div class="modal-content bg-white p-8 rounded-lg shadow-xl relative flex flex-col">
             <div class="flex justify-between items-center mb-6">
                 <h2>Material Manager</h2>
                 <button id="closeMaterialsModalBtn" class="modal-close">&times;</button>
             </div>
 
-            <!-- Горизонтальное разделение на 4 блока -->
-            <div class="flex flex-row gap-4 mb-4">
-                <!-- Блок выбора материала -->
-                <div id="materialSelectionBlock">
-                    <h3 class="mb-4">Material selection</h3>
+            <div class="modal-body flex-1 overflow-y-auto pr-4 pb-16">
+                <!-- Горизонтальное разделение на 4 блока -->
+                <div class="flex flex-row gap-4 mb-4">
+                    <!-- Блок выбора материала -->
+                    <div id="materialSelectionBlock">
+                        <h3 class="mb-4">Material selection</h3>
 
-                    <div class="mb-4">
-                        <label for="materialTypeSelect" class="block mb-2">Type:</label>
-                        <select id="materialTypeSelect" class="shadow appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"></select>
+                        <div class="mb-4">
+                            <label for="materialTypeSelect" class="block mb-2">Type:</label>
+                            <select id="materialTypeSelect" class="shadow appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"></select>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="materialStandardSelect" class="block mb-2">Standard:</label>
+                            <select id="materialStandardSelect" class="shadow appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"></select>
+                        </div>
+
+                        <div class="mb-4">
+                            <label for="materialClassSelect" class="block mb-2">Class/Grade:</label>
+                            <select id="materialClassSelect" class="block w-full pl-3 pr-10 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm"></select>
+                        </div>
+
+                        <button id="addMaterialToModelBtn" class="standard-button mt-2">Add material</button>
                     </div>
 
-                    <div class="mb-4">
-                        <label for="materialStandardSelect" class="block mb-2">Standard:</label>
-                        <select id="materialStandardSelect" class="shadow appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline"></select>
-                    </div>
+                    <!-- Блок добавления пользовательского материала -->
+                    <div id="customMaterialBlock">
+                        <h3 class="mb-2">Add User Material</h3>
+                        <div id="customMaterialFields" class="hidden p-4 border rounded-md bg-gray-50">
+                            <label for="customMaterialName" class="block mb-1">User name:</label>
+                            <input type="text" id="customMaterialName" placeholder="Name of the material" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
+                            <label for="customElasticModulus" class="block mb-1">Modulus of elasticity (MPa):</label>
+                            <input type="number" id="customElasticModulus" placeholder="For example, 2.1e11" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
+                            <label for="customDensity" class="block mb-1">Density (kg/m³):</label>
+                            <input type="number" id="customDensity" placeholder="For example, 7850" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
+                            <label for="customPoissonRatio" class="block mb-1">Poisson's ratio:</label>
+                            <input type="number" id="customPoissonRatio" step="0.01" placeholder="For example, 0.3" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
 
-                    <div class="mb-4">
-                        <label for="materialClassSelect" class="block mb-2">Class/Grade:</label>
-                        <select id="materialClassSelect" class="block w-full pl-3 pr-10 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm"></select>
-                    </div>
-                </div>
-
-                <!-- Блок добавления пользовательского материала -->
-                <div id="customMaterialFields" class="hidden p-4 border rounded-md bg-gray-50">
-                    <h3 class="mb-2">Add User Material</h3>
-                    <label for="customMaterialName" class="block mb-1">User name:</label>
-                    <input type="text" id="customMaterialName" placeholder="Name of the material" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
-                    <label for="customElasticModulus" class="block mb-1">Modulus of elasticity (MPa):</label>
-                    <input type="number" id="customElasticModulus" placeholder="For example, 2.1e11" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
-                    <label for="customDensity" class="block mb-1">Density (kg/m³):</label>
-                    <input type="number" id="customDensity" placeholder="For example, 7850" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
-                    <label for="customPoissonRatio" class="block mb-1">Poisson's ratio:</label>
-                    <input type="number" id="customPoissonRatio" step="0.01" placeholder="For example, 0.3" class="block w-full pl-3 pr-3 py-2 border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 rounded-md shadow-sm mb-2">
-
-                    <button id="saveCustomMaterialBtn" class="standard-button mt-2">Save material</button>
-                </div>
-
-                <!-- Блок свойств выбранного материала -->
-                <div id="selectedMaterialBlock">
-                    <h3 class="mb-4">Properties of material</h3>
-                    <div id="selectedMaterialProperties" class="bg-gray-100 p-4 rounded-md shadow-inner mb-6">
-                        <p class="mb-2">Name: <span id="propName">Not selected</span></p>
-                        <p>Type: <span id="propType"></span></p>
-                        <p class="mb-4">Standard: <span id="propStandard"></span></p>
-
-                        <div class="border-t border-gray-300 pt-4 mt-4">
-                            <p><span>Modulus of elasticity (E):</span> <span id="propElasticModulus"></span> <span id="unitElasticModulus" class="text-gray-500"></span></p>
-                            <p><span>Density (ρ):</span> <span id="propDensity"></span> <span id="unitDensity" class="text-gray-500"></span></p>
-                            <p><span>Poisson's ratio (ν):</span> <span id="propPoissonRatio"></span> <span id="unitPoissonRatio" class="text-gray-500"></span></p>
+                            <button id="saveCustomMaterialBtn" class="standard-button mt-2">Save material</button>
                         </div>
                     </div>
-                </div>
 
-                <!-- Блок материалов в модели -->
-                <div id="modelMaterialsBlock">
-                    <h3 class="mb-2">Materials in the model</h3>
-                    <ul id="modelMaterialList" class="border rounded-md p-3 bg-white max-h-48 overflow-y-auto">
-                        <li id="noMaterialsMessage" class="text-gray-500">There are no materials in the model</li>
-                    </ul>
+                    <!-- Блок свойств выбранного материала -->
+                    <div id="selectedMaterialBlock">
+                        <h3 class="mb-4">Properties of the selected material</h3>
+                        <div id="selectedMaterialProperties" class="bg-gray-100 p-4 rounded-md shadow-inner mb-6">
+                            <p class="mb-2">Name: <span id="propName">Not selected</span></p>
+                            <p>Type: <span id="propType"></span></p>
+                            <p class="mb-4">Standard: <span id="propStandard"></span></p>
+
+                            <div class="border-t border-gray-300 pt-4 mt-4">
+                                <p><span>Modulus of elasticity (E):</span> <span id="propElasticModulus"></span> <span id="unitElasticModulus" class="text-gray-500"></span></p>
+                                <p><span>Density (ρ):</span> <span id="propDensity"></span> <span id="unitDensity" class="text-gray-500"></span></p>
+                                <p><span>Poisson's ratio (ν):</span> <span id="propPoissonRatio"></span> <span id="unitPoissonRatio" class="text-gray-500"></span></p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Блок материалов в модели -->
+                    <div id="modelMaterialsBlock">
+                        <h3 class="mb-2">Materials in the model</h3>
+                        <ul id="modelMaterialList" class="border rounded-md p-3 bg-white max-h-48 overflow-y-auto">
+                            <li id="noMaterialsMessage" class="text-gray-500">There are no materials in the model</li>
+                        </ul>
+                    </div>
                 </div>
             </div>
 
-            <!-- Кнопки снизу -->
-            <div class="flex justify-end space-x-3">
-                <button id="addMaterialToModelBtn" class="standard-button">Add material</button>
-                <button id="closeMaterialsModalBtnBottom" class="standard-button">Close</button>
-            </div>
+            <button id="closeMaterialsModalBtnBottom" class="standard-button">Close</button>
         </div>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -488,8 +488,9 @@
             border-radius: 0.5rem;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
             max-width: none;
-            max-height: 500px;
-            overflow-y: auto;
+            height: 550px;
+            overflow: hidden;
+            position: relative;
         }
 
         #sectionsModal {
@@ -829,14 +830,25 @@
 }
 
 #materialsModal #materialSelectionBlock {
-    flex: 0 0 130px;
-    width: 130px;
+    flex: 0 0 150px;
+    width: 150px;
 }
-#materialsModal #selectedMaterialBlock,
-#materialsModal #modelMaterialsBlock,
-#materialsModal #customMaterialFields {
+#materialsModal #selectedMaterialBlock {
+    flex: 0 0 250px;
+    width: 250px;
+}
+#materialsModal #modelMaterialsBlock {
+    flex: 0 0 250px;
+    width: 250px;
+}
+#materialsModal #customMaterialBlock {
     flex: 0 0 210px;
     width: 210px;
+}
+#materialsModal #closeMaterialsModalBtnBottom {
+    position: absolute;
+    right: 2rem;
+    bottom: 2rem;
 }
 
 


### PR DESCRIPTION
## Summary
- refine Material Manager modal layout with fixed height and bottom-aligned close button
- resize selection and property panels and relocate Add Material button
- reposition Add User Material heading above its form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892e0cdc594832c9554ac1d6ad5441f