### PR TITLE
Add results loading and diagram display

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,9 +54,10 @@
         <div class="file-menu">
             <span class="menu-title">Results</span>
             <div class="dropdown-menu">
-                <div>My</div>
-                <div>Qz</div>
-                <div>Uxy</div>
+                <div id="loadResultsBtn">Load results</div>
+                <div id="resultsMyMenu">My</div>
+                <div id="resultsQzMenu">Qz</div>
+                <div id="resultsUxyMenu">Uxy</div>
             </div>
         </div>
     </div>
@@ -76,6 +77,7 @@
     </div>
 
     <input type="file" id="fileInput" accept=".json" class="hidden">
+    <input type="file" id="resultsInput" accept=".json" class="hidden">
 
 
     <!-- Основное содержимое приложения -->

--- a/js/dom.js
+++ b/js/dom.js
@@ -13,6 +13,11 @@
         const saveModelBtn = document.getElementById('saveModelBtn');
         const loadModelBtn = document.getElementById('loadModelBtn');
         const fileInput = document.getElementById('fileInput');
+        const resultsInput = document.getElementById('resultsInput');
+        const loadResultsBtn = document.getElementById('loadResultsBtn');
+        const resultsMyMenu = document.getElementById('resultsMyMenu');
+        const resultsQzMenu = document.getElementById('resultsQzMenu');
+        const resultsUxyMenu = document.getElementById('resultsUxyMenu');
         const importMenuItem = document.getElementById('importMenuItem');
         const exportMenuItem = document.getElementById('exportMenuItem');
         const shareMenu = document.getElementById('shareMenu');

--- a/js/state.js
+++ b/js/state.js
@@ -6,10 +6,19 @@
         let nextElemId = 1; 
 		let nodeLoads = [];
         let nextLoadId = 1;
-		let elementLoads = [];
+        let elementLoads = [];
         let nextElementLoadId = 1;
-		
-		let selectedElements = [];
+
+        // Results and auxiliary mappings
+        let rodResults = [];
+        let nodesById = {};
+
+        // Flags for result diagrams
+        let showMy = false;
+        let showQ = false;
+        let showU = false;
+
+        let selectedElements = [];
 		
 		// --- Глобальные переменные для работы с материалами ---
         let allMaterials = []; // Здесь будут храниться все загруженные материалы


### PR DESCRIPTION
## Summary
- allow loading of result JSON files and map rod diagrams to model lines
- track nodes by id and store rod results for drawing
- render My, Qz and Uxy diagrams with toggleable menu items

## Testing
- `node --check js/state.js && echo "state.js ok"`
- `node --check js/dom.js && echo "dom.js ok"`
- `node --check js/main.js && echo "main.js ok"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945e3a1c7c832cafbbea7219e5c099