### PR TITLE
Initialize UI before data loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div id="loadingIndicator" class="fixed top-2 right-2 bg-gray-800 text-white px-4 py-2 rounded hidden">Загрузка данных...</div>
 
     <div class="floating-panel left">
         <img src="images/logo_RodX.png" alt="RodX logo" class="left-panel-logo">

--- a/js/main.js
+++ b/js/main.js
@@ -122,10 +122,10 @@
 		}
 
         function init() {
-            snapToGridCheckbox.checked = snapToGrid; 
-            resizeCanvas();
             addEventListeners();
-            
+            snapToGridCheckbox.checked = snapToGrid;
+            resizeCanvas();
+
             forceUnitsSelect.value = 'kN';
             forceUnitsSelect.dataset.previousValue = 'kN';
 
@@ -133,9 +133,9 @@
             currentUnit = unitsSelect.value;
             currentForceUnit = forceUnitsSelect.value;
             unitsSelect.dispatchEvent(new Event('change'));
-            
-            updateUnitPairsSelect(); 
-            updateForceUnitDisplay(); 
+
+            updateUnitPairsSelect();
+            updateForceUnitDisplay();
         }
 
         function resizeCanvas() {
@@ -4108,14 +4108,24 @@ let sectionsModal;
                 addSectionToModelBtn.addEventListener('click', addSelectedSectionToModel);
             }
             
-			// --- Инициализируем селекторы материалов и загружаем данные ---\
-            await initializeMaterialSelectors();
-            await initializeSectionSelectors();
-            
+                        // --- Инициализируем селекторы материалов и загружаем данные ---\
+            const loadingIndicator = document.getElementById('loadingIndicator');
+            if (loadingIndicator) loadingIndicator.classList.remove('hidden');
+
             // --- 3. Запускаем основную инициализацию приложения ---\
-            init(); 
-            console.log('Initialization complete.'); 
-        });	
+            init();
+
+            Promise.all([
+                initializeMaterialSelectors(),
+                initializeSectionSelectors()
+            ])
+                .catch(error => console.error('Error initializing selectors:', error))
+                .finally(() => {
+                    if (loadingIndicator) loadingIndicator.classList.add('hidden');
+                });
+
+            console.log('Initialization complete.');
+        });
 		
 		
 		


### PR DESCRIPTION
## Summary
- Register UI event handlers immediately by calling `addEventListeners` at the start of `init`.
- Start material and section selector setup after `init` using `Promise.all` and show a loading indicator while data loads.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RodX/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68948ed1b2b8832c976b6e2e5b8a7a13