### PR TITLE
Add analyze menu and toggleable result displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,10 @@
             </div>
         </div>
         <div class="left-panel-separator"></div>
+        <div class="share-menu">
+            <span class="menu-title">Analyze››</span>
+        </div>
+        <div class="left-panel-separator"></div>
         <div class="file-menu">
             <span class="menu-title">Results</span>
             <div class="dropdown-menu">

--- a/js/main.js
+++ b/js/main.js
@@ -1421,21 +1421,45 @@
 
             if (resultsMyMenuItem) {
                 resultsMyMenuItem.addEventListener('click', () => {
-                    activeDiagram = 'My';
+                    if (activeDiagram === 'My') {
+                        activeDiagram = null;
+                        resultsMyMenuItem.classList.remove('active');
+                    } else {
+                        activeDiagram = 'My';
+                        resultsMyMenuItem.classList.add('active');
+                        if (resultsQzMenuItem) resultsQzMenuItem.classList.remove('active');
+                        if (resultsUxyMenuItem) resultsUxyMenuItem.classList.remove('active');
+                    }
                     draw();
                 });
             }
 
             if (resultsQzMenuItem) {
                 resultsQzMenuItem.addEventListener('click', () => {
-                    activeDiagram = 'Qz';
+                    if (activeDiagram === 'Qz') {
+                        activeDiagram = null;
+                        resultsQzMenuItem.classList.remove('active');
+                    } else {
+                        activeDiagram = 'Qz';
+                        resultsQzMenuItem.classList.add('active');
+                        if (resultsMyMenuItem) resultsMyMenuItem.classList.remove('active');
+                        if (resultsUxyMenuItem) resultsUxyMenuItem.classList.remove('active');
+                    }
                     draw();
                 });
             }
 
             if (resultsUxyMenuItem) {
                 resultsUxyMenuItem.addEventListener('click', () => {
-                    activeDiagram = 'Uxy';
+                    if (activeDiagram === 'Uxy') {
+                        activeDiagram = null;
+                        resultsUxyMenuItem.classList.remove('active');
+                    } else {
+                        activeDiagram = 'Uxy';
+                        resultsUxyMenuItem.classList.add('active');
+                        if (resultsMyMenuItem) resultsMyMenuItem.classList.remove('active');
+                        if (resultsQzMenuItem) resultsQzMenuItem.classList.remove('active');
+                    }
                     draw();
                 });
             }
@@ -1443,6 +1467,7 @@
             if (resultsReactionsMenuItem) {
                 resultsReactionsMenuItem.addEventListener('click', () => {
                     showReactions = !showReactions;
+                    resultsReactionsMenuItem.classList.toggle('active', showReactions);
                     draw();
                 });
             }

--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@
             position: absolute;
             left: 10px;
             top: calc(50px + 10px + 10px);
-            bottom: calc(43px + 300px + 0px);
+            bottom: calc(43px + 300px + 10px);
             width: 300px;
             background-color: #ffffff;
             padding: 15px;
@@ -683,6 +683,13 @@
 
 .file-menu .dropdown-menu div:hover {
     background-color: #E1F6EF;
+    color: #529774;
+    text-decoration: underline;
+    text-decoration-thickness: 9%;
+}
+
+.file-menu .dropdown-menu div.active {
+    background-color: #a7d9f7;
     color: #529774;
     text-decoration: underline;
     text-decoration-thickness: 9%;


### PR DESCRIPTION
## Summary
- Insert Analyze›› menu between Visibility and Results in the top toolbar
- Implement toggle behaviour and highlighting for Results menu items
- Maintain 10px gap between model tree and properties panels

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689578818110832cb525af3fa61cd6a4