### PR TITLE
Adjust top panel width and relocate upload control

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,17 +57,16 @@
             <span class="menu-title">Analyze››</span>
         </div>
         <div class="left-panel-separator"></div>
-        <div class="file-menu">
-            <span class="menu-title">Results</span>
-            <div class="dropdown-menu">
-                <div id="resultsUploadMenuItem">Upload</div>
-                <div id="resultsMyMenuItem">My</div>
-                <div id="resultsQzMenuItem">Qz</div>
-                <div id="resultsUxyMenuItem">Uxy</div>
-                <div id="resultsReactionsMenuItem">Reactions</div>
+            <div class="file-menu">
+                <span class="menu-title">Results</span>
+                <div class="dropdown-menu">
+                    <div id="resultsMyMenuItem">My</div>
+                    <div id="resultsQzMenuItem">Qz</div>
+                    <div id="resultsUxyMenuItem">Uxy</div>
+                    <div id="resultsReactionsMenuItem">Reactions</div>
+                </div>
             </div>
         </div>
-    </div>
     <div class="floating-panel right">
         <div id="allProjectsMenu" class="share-menu">
             <span class="menu-title">All Projects</span>
@@ -337,6 +336,7 @@
             <label for="snapToGrid">Grid snap</label>
             <input type="checkbox" id="snapToGrid">
         </div>
+        <button id="resultsUploadButton" title="Upload results">/</button>
     </div>
 
     <!-- Контекстное меню и тултип -->

--- a/js/dom.js
+++ b/js/dom.js
@@ -16,7 +16,7 @@
         const importMenuItem = document.getElementById('importMenuItem');
         const exportMenuItem = document.getElementById('exportMenuItem');
         const shareMenu = document.getElementById('shareMenu');
-        const resultsUploadMenuItem = document.getElementById('resultsUploadMenuItem');
+        const resultsUploadButton = document.getElementById('resultsUploadButton');
         const resultsMyMenuItem = document.getElementById('resultsMyMenuItem');
         const resultsQzMenuItem = document.getElementById('resultsQzMenuItem');
         const resultsUxyMenuItem = document.getElementById('resultsUxyMenuItem');

--- a/js/main.js
+++ b/js/main.js
@@ -1400,8 +1400,8 @@
                 shareMenu.addEventListener('click', () => {});
             }
 
-            if (resultsUploadMenuItem && resultsFileInput) {
-                resultsUploadMenuItem.addEventListener('click', () => {
+            if (resultsUploadButton && resultsFileInput) {
+                resultsUploadButton.addEventListener('click', () => {
                     resultsFileInput.click();
                 });
             }

--- a/style.css
+++ b/style.css
@@ -428,16 +428,28 @@
             cursor: pointer; 
             border-color: #007bff;
         }
-        #bottomBar button:hover { background-color: #0056b3; border-color: #0056b3; }
-        #bottomBar #clearCanvasBtn { background-color: #dc3545; border-color: #dc3545;}
-        #bottomBar #clearCanvasBtn:hover { background-color: #c82333; border-color: #bd2130;}
+#bottomBar button:hover { background-color: #0056b3; border-color: #0056b3; }
+#bottomBar #clearCanvasBtn { background-color: #dc3545; border-color: #dc3545;}
+#bottomBar #clearCanvasBtn:hover { background-color: #c82333; border-color: #bd2130;}
 
-        /* Контейнер элементов нижней панели */
-        #bottomBarContent {
-            display: flex;
-            align-items: center;
-            gap: 10px;
-        }
+/* Контейнер элементов нижней панели */
+#bottomBarContent {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Кнопка загрузки результатов в нижней панели */
+#resultsUploadButton {
+    position: absolute;
+    right: 5px;
+    bottom: 3px;
+    background: transparent;
+    border: none;
+    color: #888888;
+    font-size: 16px;
+    cursor: pointer;
+}
 
 
         /* Стили для тултипа и контекстного меню */
@@ -588,7 +600,7 @@
     left: 10px;
 }
 .floating-panel.center {
-    width: 570px;
+    width: 590px;
     left: 60%;
     transform: translateX(-50%);
 }


### PR DESCRIPTION
## Summary
- widen the central floating panel to 590px
- move the Upload action from Results menu to a subtle '/' button in the bottom right
- wire JavaScript to handle the new upload button

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895824fb700832c9aeb2d5977628217