### PR TITLE
Shift results upload to Analyze menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
             </div>
         </div>
         <div class="left-panel-separator"></div>
-        <div class="share-menu">
+        <div id="analyzeMenu" class="share-menu">
             <span class="menu-title">Analyze››</span>
         </div>
         <div class="left-panel-separator"></div>
@@ -336,7 +336,6 @@
             <label for="snapToGrid">Grid snap</label>
             <input type="checkbox" id="snapToGrid">
         </div>
-        <button id="resultsUploadButton" title="Upload results">/</button>
     </div>
 
     <!-- Контекстное меню и тултип -->

--- a/js/dom.js
+++ b/js/dom.js
@@ -16,7 +16,7 @@
         const importMenuItem = document.getElementById('importMenuItem');
         const exportMenuItem = document.getElementById('exportMenuItem');
         const shareMenu = document.getElementById('shareMenu');
-        const resultsUploadButton = document.getElementById('resultsUploadButton');
+        const analyzeMenu = document.getElementById('analyzeMenu');
         const resultsMyMenuItem = document.getElementById('resultsMyMenuItem');
         const resultsQzMenuItem = document.getElementById('resultsQzMenuItem');
         const resultsUxyMenuItem = document.getElementById('resultsUxyMenuItem');

--- a/js/main.js
+++ b/js/main.js
@@ -1400,8 +1400,8 @@
                 shareMenu.addEventListener('click', () => {});
             }
 
-            if (resultsUploadButton && resultsFileInput) {
-                resultsUploadButton.addEventListener('click', () => {
+            if (analyzeMenu && resultsFileInput) {
+                analyzeMenu.addEventListener('click', () => {
                     resultsFileInput.click();
                 });
             }

--- a/style.css
+++ b/style.css
@@ -439,19 +439,6 @@
     gap: 10px;
 }
 
-/* Кнопка загрузки результатов в нижней панели */
-#resultsUploadButton {
-    position: absolute;
-    right: 5px;
-    bottom: 3px;
-    background: transparent;
-    border: none;
-    color: #888888;
-    font-size: 16px;
-    cursor: pointer;
-}
-
-
         /* Стили для тултипа и контекстного меню */
         .tooltip {
             position: absolute;


### PR DESCRIPTION
## Summary
- Remove obsolete results upload button from bottom toolbar.
- Trigger results loading dialog from the Analyze≫ control in the top center panel.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895872b72a4832cb6d94bd75e4eded3