### PR TITLE
Rename lines model type to elements

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
         function saveModel() {
             const modelData = {
                 nodes: nodes,
-                lines: lines,
+                elements: lines,
                 restrictions: restrictions,
                 nodeLoads: nodeLoads,
                 elementLoads: elementLoads,
@@ -36,7 +36,7 @@
                 const modelData = JSON.parse(jsonFileContent);
 
                 nodes = modelData.nodes || [];
-                lines = (modelData.lines || []).map(l => ({
+                lines = (modelData.elements || []).map(l => ({
                     ...l,
                     sectionId: l.sectionId !== undefined ? l.sectionId : null,
                     betaAngle: l.betaAngle !== undefined ? l.betaAngle : 0

--- a/test/Frame_01.json
+++ b/test/Frame_01.json
@@ -16,7 +16,7 @@
       "y": 2
     }
   ],
-  "lines": [
+  "elements": [
     {
       "elem_id": 1,
       "nodeId1": 1,


### PR DESCRIPTION
## Summary
- save and load model data using `elements` key instead of `lines`
- update sample Frame_01.json to reflect `elements`

## Testing
- `python -m json.tool test/Frame_01.json`
- `node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); console.log('elements', data.elements.length);"`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00a0996ac832c9d2742b00b8a365a