### PR TITLE
Update references for renamed material and section files

### DIFF
--- a/data/standards.json
+++ b/data/standards.json
@@ -5,7 +5,8 @@
     "shortName": "RU",
     "country": "Russia",
     "description": "Standards of the Russian Federation",
-    "materialFile": "data/materials/ru_materials.json"
+    "materialFile": "data/materials/ru_materials.json",
+    "sectionFile": "data/sections/ru_sections.json"
   },
   {
     "id": "EU",
@@ -13,7 +14,8 @@
     "shortName": "EU",
     "country": "European Union",
     "description": "European standards",
-    "materialFile": "data/materials/eu_materials.json"
+    "materialFile": "data/materials/eu_materials.json",
+    "sectionFile": "data/sections/eu_sections.json"
   },
   {
     "id": "US",
@@ -29,6 +31,7 @@
     "shortName": "USER",
     "country": "Local",
     "description": "Materials created and saved by the user",
-    "materialFile": "localStorage"
+    "materialFile": "localStorage",
+    "sectionFile": "localStorage"
   }
 ]

--- a/js/main.js
+++ b/js/main.js
@@ -3077,7 +3077,7 @@
             }
 
             const selectedType = materialTypeSelect.value; // 'steel' or 'concrete'
-            const selectedStandard = materialStandardSelect.value; // 'GOST_SP', 'EN', etc.
+            const selectedStandard = materialStandardSelect.value; // 'RU', 'EU', 'US', etc.
             materialClassSelect.innerHTML = ''; // Очищаем текущие опции
 
             // Получаем данные для выбранного стандарта

--- a/test/Frame_01.json
+++ b/test/Frame_01.json
@@ -22,8 +22,8 @@
       "nodeId1": 1,
       "nodeId2": 2,
       "structural_type": "beam",
-      "materialId": "en_steel_S235",
-      "sectionId": "I-beam_en_IPE-200",
+        "materialId": "en_steel_S235",
+        "sectionId": "eu_I-beam_IPE-200",
       "betaAngle": 0,
       "loads": []
     },
@@ -32,8 +32,8 @@
       "nodeId1": 2,
       "nodeId2": 3,
       "structural_type": "beam",
-      "materialId": "en_steel_S235",
-      "sectionId": "I-beam_en_IPE-200",
+        "materialId": "en_steel_S235",
+        "sectionId": "eu_I-beam_IPE-200",
       "betaAngle": 0,
       "loads": []
     }
@@ -71,7 +71,7 @@
       "id": "en_steel_S235",
       "name": "S235",
       "type": "steel",
-      "standard": "EN",
+      "standard": "EU",
       "properties": {
         "elasticModulus": {
           "value": 210,
@@ -98,7 +98,7 @@
   ],
   "sections": [
     {
-      "id": "I-beam_en_IPE-80",
+      "id": "eu_I-beam_IPE-80",
       "name": "IPE-80",
       "type": "I-beam",
       "standard": "EU",
@@ -191,7 +191,7 @@
       }
     },
     {
-      "id": "I-beam_en_IPE-200",
+      "id": "eu_I-beam_IPE-200",
       "name": "IPE-200",
       "type": "I-beam",
       "standard": "EU",


### PR DESCRIPTION
## Summary
- reference new EU and RU section JSONs in standards configuration
- clarify standard identifiers in material selection code
- adjust test frame sample to use updated EU section identifiers

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e344498832cada0698f74c1912a