### PR TITLE
Fix section type list and geometry loading in modal

### DIFF
--- a/data/sections/eu_sections.json
+++ b/data/sections/eu_sections.json
@@ -1,4 +1,4 @@
-ххх[
+[
   {
     "id": "eu_I-beam_IPE-80",
     "name": "IPE-80",

--- a/js/main.js
+++ b/js/main.js
@@ -3461,12 +3461,12 @@
                     userSectionNameContainer.classList.add('hidden');
                 }
             }
-            if (selectedSection && selectedSection.properties) {
-                const props = selectedSection.properties;
-                sectionHeightSpan.value = props.height ? props.height.value : '';
-                sectionWidthSpan.value = props.width ? props.width.value : '';
-                sectionWebThicknessSpan.value = props.webThickness ? props.webThickness.value : '';
-                sectionFlangeThicknessSpan.value = props.flangeThickness ? props.flangeThickness.value : '';
+            if (selectedSection && selectedSection.geometry) {
+                const geom = selectedSection.geometry;
+                sectionHeightSpan.value = geom.h ? geom.h.value : '';
+                sectionWidthSpan.value = geom.b ? geom.b.value : '';
+                sectionWebThicknessSpan.value = geom.tw ? geom.tw.value : '';
+                sectionFlangeThicknessSpan.value = geom.tf ? geom.tf.value : '';
             } else {
                 sectionHeightSpan.value = '';
                 sectionWidthSpan.value = '';
@@ -3490,13 +3490,22 @@
             }
 
             sectionDetailsContent.innerHTML = '';
-            if (selectedSection && selectedSection.properties) {
-                for (const key in selectedSection.properties) {
-                    if (['height','width','webThickness','flangeThickness','radius'].includes(key)) continue;
-                    const prop = selectedSection.properties[key];
-                    const p = document.createElement('p');
-                    p.textContent = `${key}: ${prop.value} ${getUnitText(prop.unit)}`;
-                    sectionDetailsContent.appendChild(p);
+            if (selectedSection) {
+                if (selectedSection.geometry) {
+                    for (const key in selectedSection.geometry) {
+                        const geomProp = selectedSection.geometry[key];
+                        const p = document.createElement('p');
+                        p.textContent = `${key}: ${geomProp.value} ${getUnitText(geomProp.unit)}`;
+                        sectionDetailsContent.appendChild(p);
+                    }
+                }
+                if (selectedSection.properties) {
+                    for (const key in selectedSection.properties) {
+                        const prop = selectedSection.properties[key];
+                        const p = document.createElement('p');
+                        p.textContent = `${key}: ${prop.value} ${getUnitText(prop.unit)}`;
+                        sectionDetailsContent.appendChild(p);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Ensure section modal reads geometry values from new `geometry` container
- Repair EU sections JSON so I-beam options load alongside C-channel

## Testing
- `python -m json.tool data/sections/eu_sections.json`
- `python -m json.tool data/sections/ru_sections.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1516e7fbc832c82520e29db13c492