### PR TITLE
Reorder model JSON structure

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,18 +1,18 @@
         function saveModel() {
             const modelData = {
-                nodes: nodes,
-                elements: lines,
-                restrictions: restrictions,
-                nodeLoads: nodeLoads,
-                elementLoads: elementLoads,
-                materials: modelMaterials,
-                sections: modelSections,
                 units: {
                     length: currentUnit,
                     force: currentForceUnit,
                     temperature: currentTemperatureUnit,
                     time: currentTimeUnit
-                }
+                },
+                nodes: nodes,
+                elements: lines,
+                supports: restrictions,
+                materials: modelMaterials,
+                sections: modelSections,
+                nodeLoads: nodeLoads,
+                elementLoads: elementLoads
             };
             
             console.log("Модель данных перед сохранением:", modelData);
@@ -41,7 +41,7 @@
                     sectionId: l.sectionId !== undefined ? l.sectionId : null,
                     betaAngle: l.betaAngle !== undefined ? l.betaAngle : 0
                 }));
-                restrictions = modelData.restrictions || [];
+                restrictions = modelData.supports || modelData.restrictions || [];
                 nodeLoads = modelData.nodeLoads || [];
                 elementLoads = modelData.elementLoads || [];
 				

--- a/test/Frame_01.json
+++ b/test/Frame_01.json
@@ -1,4 +1,10 @@
 {
+  "units": {
+    "length": "m",
+    "force": "kN",
+    "temperature": "C",
+    "time": "s"
+  },
   "nodes": [
     {
       "node_id": 1,
@@ -22,8 +28,8 @@
       "nodeId1": 1,
       "nodeId2": 2,
       "structural_type": "beam",
-        "materialId": "en_steel_S235",
-        "sectionId": "eu_I-beam_IPE-200",
+      "materialId": "en_steel_S235",
+      "sectionId": "eu_I-beam_IPE-200",
       "betaAngle": 0,
       "loads": []
     },
@@ -32,13 +38,13 @@
       "nodeId1": 2,
       "nodeId2": 3,
       "structural_type": "beam",
-        "materialId": "en_steel_S235",
-        "sectionId": "eu_I-beam_IPE-200",
+      "materialId": "en_steel_S235",
+      "sectionId": "eu_I-beam_IPE-200",
       "betaAngle": 0,
       "loads": []
     }
   ],
-  "restrictions": [
+  "supports": [
     {
       "node_id": 1,
       "dx": 0,
@@ -50,20 +56,6 @@
       "dx": 1,
       "dy": 1,
       "dr": 1
-    }
-  ],
-  "nodeLoads": [],
-  "elementLoads": [
-    {
-      "load_id": 1,
-      "target_elem_id": 1,
-      "type": "uniform",
-      "component": "y",
-      "startValue": -2,
-      "endValue": -2,
-      "unit": "kN/m",
-      "startPosition": 0,
-      "endPosition": 1
     }
   ],
   "materials": [
@@ -284,10 +276,18 @@
       }
     }
   ],
-  "units": {
-    "length": "m",
-    "force": "kN",
-    "temperature": "C",
-    "time": "s"
-  }
+  "nodeLoads": [],
+  "elementLoads": [
+    {
+      "load_id": 1,
+      "target_elem_id": 1,
+      "type": "uniform",
+      "component": "y",
+      "startValue": -2,
+      "endValue": -2,
+      "unit": "kN/m",
+      "startPosition": 0,
+      "endPosition": 1
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- save models with `units` first and `supports` collection
- adjust JSON loader to read `supports` or legacy `restrictions`
- reformat Frame_01.json example to new structure

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b161d21210832cadfbb9445a920c57