### PR TITLE
Remove loads property from elements

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -64,10 +64,10 @@
                 const modelData = JSON.parse(jsonFileContent);
 
                 nodes = modelData.nodes || [];
-                lines = (modelData.elements || []).map(l => ({
-                    ...l,
-                    sectionId: l.sectionId !== undefined ? l.sectionId : null,
-                    betaAngle: l.betaAngle !== undefined ? l.betaAngle : 0
+                lines = (modelData.elements || []).map(({ loads, ...rest }) => ({
+                    ...rest,
+                    sectionId: rest.sectionId !== undefined ? rest.sectionId : null,
+                    betaAngle: rest.betaAngle !== undefined ? rest.betaAngle : 0
                 }));
                 restrictions = modelData.supports || modelData.restrictions || [];
                 nodalLoads = [];
@@ -1737,7 +1737,7 @@
 							(line.nodeId1 === clickedNode.nodeId && line.nodeId2 === firstNodeForLine.nodeId)    
 						);
                                                 if (!exists) {
-                                                        lines.push({ elemId: nextElemId++, nodeId1: firstNodeForLine.nodeId, nodeId2: clickedNode.nodeId, structuralType: 'beam', materialId: null, sectionId: null, betaAngle: 0, loads: [] });
+                                                        lines.push({ elemId: nextElemId++, nodeId1: firstNodeForLine.nodeId, nodeId2: clickedNode.nodeId, structuralType: 'beam', materialId: null, sectionId: null, betaAngle: 0 });
                                                         console.log(`Линия ${nextElemId - 1} создана между узлами ${firstNodeForLine.nodeId} и ${clickedNode.nodeId}.`);
                                                 } else {
 							console.log(`Линия между узлами ${firstNodeForLine.nodeId} и ${clickedNode.nodeId} уже существует.`); 

--- a/test/Frame_01.json
+++ b/test/Frame_01.json
@@ -30,8 +30,7 @@
       "structuralType": "beam",
       "materialId": "en_steel_S235",
       "sectionId": "eu_I-beam_IPE-200",
-      "betaAngle": 0,
-      "loads": []
+      "betaAngle": 0
     },
     {
       "elemId": 2,
@@ -40,8 +39,7 @@
       "structuralType": "beam",
       "materialId": "en_steel_S235",
       "sectionId": "eu_I-beam_IPE-200",
-      "betaAngle": 0,
-      "loads": []
+      "betaAngle": 0
     }
   ],
   "supports": [


### PR DESCRIPTION
## Summary
- remove empty `loads` arrays from element definitions
- stop including `loads` in new elements and strip it when loading models

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/main.js`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); console.log('JSON valid');"`


------
https://chatgpt.com/codex/tasks/task_e_68b17b125d38832c995f3dff906f7af1