### PR TITLE
Improve elastic support boundary UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -888,6 +888,9 @@
     width: 60px;
     margin-left: 8px;
 }
+.property-group .checkbox-group input.elastic-input:disabled {
+    background-color: #e5e7eb;
+}
 .property-group .checkbox-group .k-unit {
     margin-left: 4px;
     font-size: 0.8em;


### PR DESCRIPTION
## Summary
- Leave stiffness fields kx/ky/kr blank by default and gray them when constrained
- Derive active support icon from either checkboxes or nonzero stiffnesses

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b668f77500832c9460b8394eb989f0