### PR TITLE
Add default gravity container to model JSON

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -42,6 +42,7 @@ function removeElasticSupportIfZero(es) {
             temperature: currentTemperatureUnit,
             time: currentTimeUnit
         },
+        gravity: gravity,
         nodes: nodes,
         elements: lines,
         supports: restrictions,
@@ -85,6 +86,7 @@ function removeElasticSupportIfZero(es) {
                 restrictions = modelData.supports || modelData.restrictions || [];
                 elasticSupports = (modelData.elasticSupports || []).filter(es => es.kx !== 0 || es.ky !== 0 || es.kr !== 0);
                 connectors = modelData.connectors || [];
+                gravity = modelData.gravity || { g: 9.81, direction: [0, 0, -1] };
                 nodalLoads = [];
                 elementLoads = [];
                 if (modelData.loads) {

--- a/js/state.js
+++ b/js/state.js
@@ -48,6 +48,10 @@ let nextLoadCaseId = 2;
         let currentForceUnit = forceUnitsSelect.value;
         let currentTemperatureUnit = 'C';
         let currentTimeUnit = 's';
+        let gravity = {
+            g: 9.81,
+            direction: [0, 0, -1]
+        };
 
         // === Beta Angle Icons ===
         const betaAngleIconSizeWorld = 20; // icon size in pixels

--- a/test/Frame_01 (results).json
+++ b/test/Frame_01 (results).json
@@ -4,6 +4,10 @@
       "force": "kN",
       "length": "m"
     },
+    "gravity": {
+      "g": 9.81,
+      "direction": [0, 0, -1]
+    },
     "rods": [
       {
         "elemId": 1,

--- a/test/Frame_01.json
+++ b/test/Frame_01.json
@@ -5,6 +5,10 @@
     "temperature": "C",
     "time": "s"
   },
+  "gravity": {
+    "g": 9.81,
+    "direction": [0, 0, -1]
+  },
   "nodes": [
     {
       "nodeId": 1,


### PR DESCRIPTION
## Summary
- Define global gravity settings and export them with model data
- Load gravity parameters when importing model JSON
- Update sample JSON files with default gravity block

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); console.log('Frame_01.json OK');" && node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('test/Frame_01 (results).json','utf8')); console.log('Frame_01 (results).json OK');"`


------
https://chatgpt.com/codex/tasks/task_e_68b7b4197bf4832cb72c8bba95e2d127