### PR TITLE
Fix moment unit parsing to enable proper unit conversion

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -138,10 +138,13 @@ function removeElasticSupportIfZero(es) {
                             let unit = load.units;
                             let lengthUnit = null;
                             if (type === 'moment') {
-                                const match = load.units.match(/^([a-zA-Z]+)([a-zA-Z]+)$/);
-                                if (match) {
-                                    unit = match[1];
-                                    lengthUnit = match[2];
+                                const knownLengthUnits = Object.keys(lengthUnitConversions);
+                                for (const lu of knownLengthUnits) {
+                                    if (unit.endsWith(lu)) {
+                                        lengthUnit = lu;
+                                        unit = unit.slice(0, -lu.length);
+                                        break;
+                                    }
                                 }
                             }
                             const nodalLoad = {


### PR DESCRIPTION
## Summary
- Parse moment unit strings by detecting known length units rather than using a greedy regex
- Ensure nodal moment loads convert correctly when switching unit systems

## Testing
- `node -e 'const forceUnitConversions={N:1,kN:1000,kg:9.80665,t:9806.65,lbf:4.44822,kips:4448.22}; const lengthUnitConversions={m:1,cm:0.01,mm:0.001,in:0.0254,ft:0.3048}; function convertMoment(value, fromForceUnit, fromLengthUnit, toForceUnit, toLengthUnit){if(!forceUnitConversions[fromForceUnit]||!forceUnitConversions[toForceUnit]||!lengthUnitConversions[fromLengthUnit]||!lengthUnitConversions[toLengthUnit]) return value; const momentInNM=value*forceUnitConversions[fromForceUnit]*lengthUnitConversions[fromLengthUnit]; return momentInNM/(forceUnitConversions[toForceUnit]*lengthUnitConversions[toLengthUnit]);} function parse(unitStr){let unit=unitStr, lengthUnit=null; for(const lu of Object.keys(lengthUnitConversions)){ if(unit.endsWith(lu)){ lengthUnit=lu; unit=unit.slice(0,-lu.length); break; } } return {unit,lengthUnit}; } const parsed=parse("lbfft"); console.log(parsed); let val=100; let valLen=convertMoment(val, parsed.unit, parsed.lengthUnit, parsed.unit, "m"); console.log("len conv", valLen.toFixed(5)); let valForce=convertMoment(valLen, parsed.unit, "m", "kN", "m"); console.log("force conv", valForce.toFixed(5));'`
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b7c6e8f18c832c9caf598f4b26bc29