### PR TITLE
Add browser-based INP export

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
             <div class="dropdown-menu">
                 <div id="importMenuItem">Import</div>
                 <div id="exportMenuItem">Export</div>
+                <div id="exportToInpMenuItem">Export to inp</div>
             </div>
         </div>
         <div id="shareMenu" class="share-menu">
@@ -382,6 +383,7 @@
     </div>
     <div id="tooltip" class="tooltip hidden"></div>
     <div id="cursorTooltip" class="tooltip hidden"></div>
+    <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script src="js/dom.js"></script>
     <script src="js/state.js"></script>
     <script src="js/main.js"></script>

--- a/js/dom.js
+++ b/js/dom.js
@@ -15,6 +15,7 @@
         const fileInput = document.getElementById('fileInput');
         const importMenuItem = document.getElementById('importMenuItem');
         const exportMenuItem = document.getElementById('exportMenuItem');
+        const exportToInpMenuItem = document.getElementById('exportToInpMenuItem');
         const shareMenu = document.getElementById('shareMenu');
         const analyzeMenu = document.getElementById('analyzeMenu');
         const resultsMyMenuItem = document.getElementById('resultsMyMenuItem');


### PR DESCRIPTION
## Summary
- add **Export to inp** option in File menu
- run `json_to_inp.py` via Pyodide to generate `beam.inp`
- include Pyodide runtime

## Testing
- `python -m py_compile py/json_to_inp.py`
- `node --check js/main.js`
- `node --check js/dom.js`


------
https://chatgpt.com/codex/tasks/task_e_68b814096108832c9f97893dd6044715