### PR TITLE
Fix loadById redeclaration causing convertJsonToInp undefined

### DIFF
--- a/js/json2inp_Ibeam_rect.js
+++ b/js/json2inp_Ibeam_rect.js
@@ -164,7 +164,8 @@ function convertJsonToInp(model){
   }
 
   // Steps by loadCases
-  const loadById = loadByIdGlobal = loadById; // alias
+  // Alias to expose loads mapping if needed elsewhere without redeclaration issues
+  const loadByIdGlobal = loadById;
   for(const lc of (model.loadCases||[])){
     out.push(`*STEP, NLGEOM=NO`);
     out.push(`*STATIC`);


### PR DESCRIPTION
## Summary
- fix duplicate `loadById` declaration in INP converter and expose mapping via `loadByIdGlobal`

## Testing
- `node js/json2inp_Ibeam_rect.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b85ecd8c80832c9a30d2f9d870a444