### PR TITLE
Fix INP export by isolating converter script

### DIFF
--- a/js/json2inp_Ibeam_rect.js
+++ b/js/json2inp_Ibeam_rect.js
@@ -2,6 +2,8 @@
 // Convert model JSON → CalculiX .inp (B31). I-beam is composed as 3 RECT sections with OFFSETS.
 // Units normalized to mm–N–s–K. Supports β-rotation (about local axis 1) for each element.
 
+(function (global) {
+
 const conv = {
   length(x, u="mm"){u=u.toLowerCase();
     if(u==="mm")return x; if(u==="m"||u==="meter"||u==="meters")return x*1000;
@@ -197,8 +199,12 @@ function convertJsonToInp(model){
   return out.join("\n")+"\n";
 }
 
-// Exports for Node:
-// module.exports = { convertJsonToInp, iBeamToRECTs };
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { convertJsonToInp, iBeamToRECTs };
+} else {
+  global.convertJsonToInp = convertJsonToInp;
+  global.iBeamToRECTs = iBeamToRECTs;
+}
 
 /*
 Usage:
@@ -207,3 +213,5 @@ const data = JSON.parse(readFileSync("beam_kN_m.json","utf8"));
 const inp  = convertJsonToInp(data);
 writeFileSync("model.inp", inp, "utf8");
 */
+
+})(typeof window !== "undefined" ? window : globalThis);


### PR DESCRIPTION
## Summary
- Wrap INP converter in an IIFE to avoid global name collisions
- Expose `convertJsonToInp` globally or via `module.exports` so main.js can export models

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp_Ibeam_rect.js'); console.log(typeof convertJsonToInp);"`
- `node -e "const {convertJsonToInp}=require('./js/json2inp_Ibeam_rect.js'); const model={units:{length:'mm',force:'N'}, nodes:[], elements:[], materials:[], sections:[{id:'s1',type:'I-beam',geometry:{h:{value:100},b:{value:50},tw:{value:5},tf:{value:10}}}], loads:[], loadCases:[]}; console.log(convertJsonToInp(model).split('\n').slice(0,5).join('\n'));"`


------
https://chatgpt.com/codex/tasks/task_e_68b8e457ca48832ca3e38980af5859d8