### PR TITLE
Skip conversion when properties already in mm units

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -92,9 +92,15 @@ function convertJsonToInp(model){
     const key = `${e.sectionId}_${e.materialId}_${st}`;
     let g = gmap[key];
     if (!g) {
-      const A  = conv.area(e.A?.value||0,  (e.A&&e.A.unit)  || (LEN_U+"^2"));
-      const Iy = conv.inertia(e.Iy?.value||0, (e.Iy&&e.Iy.unit)|| (LEN_U+"^4"));
-      const Iz = conv.inertia(e.Iz?.value||0, (e.Iz&&e.Iz.unit)|| (LEN_U+"^4"));
+      // element properties may already be in mm-N-s-K system. If units
+      // match, avoid an unnecessary conversion to keep original values.
+      const A_u  = (e.A && e.A.unit)  || (LEN_U + "^2");
+      const Iy_u = (e.Iy && e.Iy.unit) || (LEN_U + "^4");
+      const Iz_u = (e.Iz && e.Iz.unit) || (LEN_U + "^4");
+
+      const A  = (e.A  && A_u.toLowerCase()  === "mm^2") ? +e.A.value  : conv.area(e.A?.value||0,  A_u);
+      const Iy = (e.Iy && Iy_u.toLowerCase() === "mm^4") ? +e.Iy.value : conv.inertia(e.Iy?.value||0, Iy_u);
+      const Iz = (e.Iz && Iz_u.toLowerCase() === "mm^4") ? +e.Iz.value : conv.inertia(e.Iz?.value||0, Iz_u);
       g = gmap[key] = { name: key, st, material: e.materialId, A, Iy, Iz, elems: [] };
       groups.push(g);
     }


### PR DESCRIPTION
## Summary
- Avoid unnecessary conversion for A, Iy, and Iz when their units already use mm-based system

## Testing
- `node - <<'NODE'
const {convertJsonToInp}=require('./js/json2inp.js');
const model={units:{length:'mm'},elements:[{elemId:1,nodeId1:1,nodeId2:2,A:{value:2,unit:'mm^2'},Iy:{value:3,unit:'mm^4'},Iz:{value:4,unit:'mm^4'},materialId:'m',sectionId:'s'}],nodes:[{nodeId:1,x:0,y:0},{nodeId:2,x:1,y:0}],materials:[{id:'m',properties:{elasticModulus:{value:1,unit:'MPa'},poissonRatio:{value:0.3},density:{value:1,unit:'kg/m^3'}}}]};
console.log(convertJsonToInp(model));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68baf39d9020832ca632daeda2c23445