### PR TITLE
feat: output section areas after materials

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -129,6 +129,13 @@ function convertJsonToInp(model){
     out.push(fmt(rho));
   }
 
+  // raw areas of all elements
+  const areas = (model.elements || [])
+    .map(e => e.A && e.A.value)
+    .filter(v => v !== undefined)
+    .join(',');
+  if (areas) out.push(areas);
+
   // *ELSET blocks
   let esCnt = 1;
   for (const g of groups) {


### PR DESCRIPTION
## Summary
- list element cross-section areas after material definitions

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp');const m=require('./test/Frame_01.json');m.elements.forEach(e=>{e.A={value:42}});console.log(convertJsonToInp(m));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbaa0db320832ca7c6e033425e3cff