### PR TITLE
Remove raw area and ELSET generation in json2inp

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -126,29 +126,7 @@ function convertJsonToInp(model){
     out.push('*ELASTIC');
     out.push(`${fmt(E)}, ${fmt(nu)}`);
     out.push('*DENSITY');
-    out.push(fmt(rho));
-  }
-
-  // raw areas of all elements
-  const areas = (model.elements || [])
-    .map(e => e.A && e.A.value)
-    .filter(v => v !== undefined)
-    .join(',');
-  if (areas) out.push(areas);
-
-  // *ELSET blocks
-  let esCnt = 1;
-  for (const g of groups) {
-    out.push(`*ELSET, ELSET=${JSON.stringify(g.name)}`);
-    out.push(String(esCnt++));
-    if (g.st === 'beam') {
-      out.push(`*BEAM SECTION, ELSET=${JSON.stringify(g.name)}, MATERIAL=${JSON.stringify(g.material)}, SECTION=GENERAL`);
-      out.push(`${fmt(g.A)}, ${fmt(g.Iy)}, 0.0, ${fmt(g.Iz)}, 10000`);
-      out.push('0, 0, -1');
-    } else if (g.st === 'truss') {
-      out.push(`*SOLID SECTION, ELSET=${JSON.stringify(g.name)}, MATERIAL=${JSON.stringify(g.material)}`);
-      out.push(fmt(g.A));
-    }
+  out.push(fmt(rho));
   }
 
   return out.join("\n")+"\n";


### PR DESCRIPTION
## Summary
- Simplify `json2inp` converter by removing raw area output and `*ELSET` block generation.

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp.js');const fs=require('fs');const data=JSON.parse(fs.readFileSync('test/Frame_01.json','utf8'));const out=convertJsonToInp(data);console.log(out.split('\n').slice(0,20).join('\n'));"`


------
https://chatgpt.com/codex/tasks/task_e_68bbae8dfe8c832cb2bfcf91303e6499