### PR TITLE
feat: include section area in inp conversion

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -129,6 +129,20 @@ function convertJsonToInp(model){
   out.push(fmt(rho));
   }
 
+  // Section areas (no unit conversion)
+  const sections = model.sections || [];
+  let wroteSec = false;
+  for (const s of sections) {
+    const A = s?.properties?.A?.value;
+    if (A !== undefined) {
+      if (!wroteSec) {
+        out.push('*SECTIONS');
+        wroteSec = true;
+      }
+      out.push(`${JSON.stringify(s.id)}, ${A}`);
+    }
+  }
+
   return out.join("\n")+"\n";
 }
 


### PR DESCRIPTION
## Summary
- output cross-section areas from `sections` as `*SECTIONS` entries in INP files
- leave values unconverted and comma-separated after `*MATERIAL`

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp.js'); const fs=require('fs'); const data=JSON.parse(fs.readFileSync('./test/Frame_01.json','utf8')); data.sections[0].properties.A={value:123}; const inp=convertJsonToInp(data); console.log(inp.split('\n').slice(-20).join('\n'));"`


------
https://chatgpt.com/codex/tasks/task_e_68bbb19e7534832ca5617e95ab8c7d79