### PR TITLE
Add Iy and Iz properties to *SECTIONS output

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -133,13 +133,20 @@ function convertJsonToInp(model){
   const sections = model.sections || [];
   let wroteSec = false;
   for (const s of sections) {
-    const A = s?.properties?.A?.value;
-    if (A !== undefined) {
+    const props = s?.properties || {};
+    const A  = props?.A?.value;
+    const Iy = props?.Iy?.value;
+    const Iz = props?.Iz?.value;
+    if (A !== undefined || Iy !== undefined || Iz !== undefined) {
       if (!wroteSec) {
         out.push('*SECTIONS');
         wroteSec = true;
       }
-      out.push(`${JSON.stringify(s.id)}, ${A}`);
+      const fields = [JSON.stringify(s.id)];
+      if (A  !== undefined) fields.push(A);
+      if (Iy !== undefined) fields.push(Iy);
+      if (Iz !== undefined) fields.push(Iz);
+      out.push(fields.join(', '));
     }
   }
 


### PR DESCRIPTION
## Summary
- include section Iy and Iz values when generating the *SECTIONS block in json2inp

## Testing
- `node - <<'NODE'
const {convertJsonToInp}=require('./js/json2inp.js');
const model={
  nodes:[], elements:[], materials:[],
  sections:[{id:'sec1', properties:{A:{value:10}, Iy:{value:20}, Iz:{value:30}}}]
};
console.log(convertJsonToInp(model));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bbb3ff345c832c9580566a25af1fbc