### PR TITLE
Remove section area handling in json2inp

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -129,27 +129,6 @@ function convertJsonToInp(model){
   out.push(fmt(rho));
   }
 
-  // Section areas (no unit conversion)
-  const sections = model.sections || [];
-  let wroteSec = false;
-  for (const s of sections) {
-    const props = s?.properties || {};
-    const A  = props?.A?.value;
-    const Iy = props?.Iy?.value;
-    const Iz = props?.Iz?.value;
-    if (A !== undefined || Iy !== undefined || Iz !== undefined) {
-      if (!wroteSec) {
-        out.push('*SECTIONS');
-        wroteSec = true;
-      }
-      const fields = [JSON.stringify(s.id)];
-      if (A  !== undefined) fields.push(A);
-      if (Iy !== undefined) fields.push(Iy);
-      if (Iz !== undefined) fields.push(Iz);
-      out.push(fields.join(', '));
-    }
-  }
-
   return out.join("\n")+"\n";
 }
 


### PR DESCRIPTION
## Summary
- streamline json2inp by dropping obsolete section area output

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp.js'); const data=require('./test/Frame_01.json'); console.log(convertJsonToInp(data).split('\n').slice(0,20).join('\n'));"`


------
https://chatgpt.com/codex/tasks/task_e_68bbb7cfe608832c9636e9c7df2ad6fa