### PR TITLE
Add boundary condition output to json2inp converter

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -117,6 +117,25 @@ function convertJsonToInp(model){
     }
   }
 
+  // *BOUNDARY
+  out.push('*BOUNDARY');
+  out.push('Nall, 3, 5');
+  for (const s of (model.supports || [])) {
+    const n = +s.nodeId;
+    if (+s.dx === 1) {
+      out.push('*BOUNDARY');
+      out.push(`${n}, 1, 1`);
+    }
+    if (+s.dy === 1) {
+      out.push('*BOUNDARY');
+      out.push(`${n}, 2, 2`);
+    }
+    if (+s.dr === 1) {
+      out.push('*BOUNDARY');
+      out.push(`${n}, 6, 6`);
+    }
+  }
+
   // *MATERIAL
   for (const m of (model.materials || [])) {
     const p = m.properties || {};


### PR DESCRIPTION
## Summary
- output *BOUNDARY section after *ELEMENT records
- emit boundary lines for supports based on dx/dy/dr flags

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp'); const fs=require('fs'); const data=JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); console.log(convertJsonToInp(data));"`

------
https://chatgpt.com/codex/tasks/task_e_68bbed9c7524832c9eae99308dc3298e