### PR TITLE
Use millimeter-scale gravity constant

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -149,7 +149,7 @@ function removeElasticSupportIfZero(es) {
                 restrictions = modelData.supports || modelData.restrictions || [];
                 elasticSupports = (modelData.elasticSupports || []).filter(es => es.kx !== 0 || es.ky !== 0 || es.kr !== 0);
                 connectors = modelData.connectors || [];
-                gravity = modelData.gravity || { g: 9.81, direction: [0, 0, -1] };
+                gravity = modelData.gravity || { g: 9810, direction: [0, 0, -1] };
 
                 if (modelData.loads) {
                     modelData.loads.forEach(load => {

--- a/js/state.js
+++ b/js/state.js
@@ -49,7 +49,7 @@ let nextLoadCaseId = 2;
         let currentTemperatureUnit = 'C';
         let currentTimeUnit = 's';
         let gravity = {
-            g: 9.81,
+            g: 9810,
             direction: [0, 0, -1]
         };
 


### PR DESCRIPTION
## Summary
- Update default gravity constant to 9810 in state and model-loading logic.
- Ensure model loading uses new gravity fallback.

## Testing
- `node --check js/state.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfb5c8e28832c9120d810af6e3d82