### PR TITLE
Adjust Load Cases modal dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
 
     <!-- Load Cases Modal -->
     <div id="loadCasesModal" class="fixed inset-0 bg-gray-600 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="bg-white p-6 rounded-lg shadow-xl w-2/3 max-h-[90vh] overflow-y-auto">
+        <div class="bg-white p-6 rounded-lg shadow-xl w-[44%] h-[80vh] overflow-y-auto">
             <div class="flex justify-between items-center mb-4">
                 <h2>Load Cases</h2>
                 <button id="closeLoadCasesModal" class="modal-close">&times;</button>


### PR DESCRIPTION
## Summary
- Fix Load Cases modal height to 80% of viewport for consistent sizing
- Reduce Load Cases modal width by roughly 1.5x for better fit

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bd11c7c9ac832c9dbf67418fe9d3bf