### PR TITLE
Move Self Weight checkbox to modal header

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,12 @@
         <div class="bg-white p-6 rounded-lg shadow-xl w-[44%] h-[80vh] overflow-y-auto">
             <div class="flex justify-between items-center mb-4">
                 <h2>Load Cases</h2>
-                <button id="closeLoadCasesModal" class="modal-close">&times;</button>
+                <div class="flex items-center">
+                    <label class="flex items-center mr-4">
+                        <input type="checkbox" id="selfWeightCheckbox" class="mr-2">Self Weight
+                    </label>
+                    <button id="closeLoadCasesModal" class="modal-close">&times;</button>
+                </div>
             </div>
             <div class="flex">
                 <div class="w-1/3 pr-4 border-r">
@@ -277,10 +282,7 @@
                 </div>
                 <div class="w-2/3 pl-4" id="loadCaseDetails"></div>
             </div>
-            <div class="flex justify-between items-center mt-4">
-                <label class="flex items-center">
-                    <input type="checkbox" id="selfWeightCheckbox" class="mr-2">Self Weight
-                </label>
+            <div class="flex justify-end items-center mt-4">
                 <button id="closeLoadCasesModalBottom" class="standard-button">Close</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Relocate Self Weight checkbox to the top-right of the Load Cases modal
- Clean up modal footer to only show the Close button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd157af91c832cafde63b5c480d562