### PR TITLE
Fix json2inp material and beam section output

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -133,15 +133,12 @@ function convertJsonToInp(model){
   for (const s of (model.supports || [])) {
     const n = +s.nodeId;
     if (+s.dx === 1) {
-      out.push('*BOUNDARY');
       out.push(`${n}, 1, 1`);
     }
     if (+s.dy === 1) {
-      out.push('*BOUNDARY');
       out.push(`${n}, 2, 2`);
     }
     if (+s.dr === 1) {
-      out.push('*BOUNDARY');
       out.push(`${n}, 6, 6`);
     }
   }
@@ -155,7 +152,7 @@ function convertJsonToInp(model){
     const E   = conv.E(+em.value, em.unit || 'MPa');
     const nu  = +pr.value;
     const rho = conv.rho(+de.value, de.unit || 'kg/m^3');
-    out.push(`*MATERIAL, NAME=${JSON.stringify(m.id)}`);
+    out.push(`*MATERIAL, NAME=${m.id}`);
     out.push('*ELASTIC');
     out.push(`${fmt(E)}, ${fmt(nu)}`);
     out.push('*DENSITY');
@@ -176,7 +173,7 @@ function convertJsonToInp(model){
       out.push(`*ELSET, ELSET=${g.sectionId}_${g.material}`);
       out.push(`${++elsetIdx}`);
       out.push(`*BEAM SECTION, ELSET=${g.name}, MATERIAL=${g.material}, SECTION=GENERAL`);
-      out.push(`${A.toFixed(4)}, ${Iy.toFixed(4)}, 0.0, ${Iz.toFixed(4)}, 10000`);
+      out.push(`${A.toFixed(4)}, ${Iz.toFixed(4)}, 0.0, ${Iy.toFixed(4)}, 10000`);
       out.push('0, 0, -1');
     } else if (g.st === 'truss') {
       out.push(`*ELSET, ELSET=${g.name}`);


### PR DESCRIPTION
## Summary
- avoid quoting material IDs in `*MATERIAL` lines
- emit a single `*BOUNDARY` block with all node constraints
- swap Iy and Iz parameters in `*BEAM SECTION`

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp.js'); const data=require('./test/Frame_01.json'); console.log(convertJsonToInp(data).split('\n').slice(0,40).join('\n'))"`

------
https://chatgpt.com/codex/tasks/task_e_68be4a674e14832cbe4d8649a0b20f05