### PR TITLE
Adjust json2inp to emit USER ELEMENT for beams

### DIFF
--- a/js/json2inp.js
+++ b/js/json2inp.js
@@ -102,10 +102,10 @@ function convertJsonToInp(model){
   // *ELEMENT
   const groups = [];
   const gmap = {};
-  let hasTruss = false;
+  let hasBeam = false;
   for (const e of elements) {
     const st = (e.structuralType || 'beam').toLowerCase();
-    if (st === 'truss') hasTruss = true;
+    if (st === 'beam') hasBeam = true;
     const key = `${e.sectionId}_${e.materialId}_${st}`;
     let g = gmap[key];
     if (!g) {
@@ -122,8 +122,8 @@ function convertJsonToInp(model){
     name: g.name,
     nodeId: g.elems.map(e => +e.elemId),
   }));
-  if (hasTruss) {
-    out.push('*USER ELEMENT, TYPE=U1, NODES=2, INTEGRATION POINTS=2, MAXDOF=2');
+  if (hasBeam) {
+    out.push('*USER ELEMENT, TYPE=U1, NODES=2, INTEGRATION POINTS=2, MAXDOF=6');
   }
   for (const g of groups) {
     let etype = 'U1';


### PR DESCRIPTION
## Summary
- Only emit the `*USER ELEMENT` definition when beam elements are present
- Increase default `MAXDOF` for user elements to 6

## Testing
- `node -e "const {convertJsonToInp}=require('./js/json2inp.js'); console.log('loaded');"`
- `node -e "const fs=require('fs'); const {convertJsonToInp}=require('./js/json2inp.js'); const data=JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); const inp=convertJsonToInp(data); const lines=inp.split('\n'); console.log(lines.filter(l=>l.startsWith('*USER ELEMENT')));"`
- `node - <<'NODE'
const {convertJsonToInp}=require('./js/json2inp.js');
const data={nodes:[{nodeId:1,x:0,y:0},{nodeId:2,x:1,y:0}], elements:[{elemId:1,nodeId1:1,nodeId2:2,structuralType:'truss',materialId:'m1',sectionId:'s1'}], materials:[{id:'m1',properties:{elasticModulus:{value:210000,unit:'MPa'},poissonRatio:{value:0.3},density:{value:7850,unit:'kg/m^3'}}}], sections:[{id:'s1',properties:{A:{value:1,unit:'mm^2'}}}], loadCases:[]};
const inp=convertJsonToInp(data);
console.log(inp);
console.log('--- USER ELEMENT lines:');
console.log(inp.split('\n').filter(l=>l.startsWith('*USER ELEMENT')));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68be5a7e04e0832c9969397189cf4d00