### PR TITLE
Convert JSON nodes to millimeters in json2tcl

### DIFF
--- a/js/json2tcl.js
+++ b/js/json2tcl.js
@@ -3,9 +3,23 @@
 
 (function (global) {
 
+const conv = {
+  length(x, u = "mm") {
+    u = String(u).toLowerCase();
+    if (u === "mm") return x;
+    if (u === "m" || u === "meter" || u === "meters") return x * 1000;
+    if (u === "cm") return x * 10;
+    if (u === "in" || u === "inch" || u === "inches") return x * 25.4;
+    if (u === "ft" || u === "feet") return x * 304.8;
+    throw Error("len " + u);
+  },
+};
+
 function convertJsonToTcl(model) {
+  const units = model.units || {};
+  const LEN_U = units.length || "mm";
   const out = [];
-  out.push("# -------------------- Units: mm, N, sec, K ---------------------------------------");
+  out.push("# -------------------- Units: mm-N-sec-K ---------------------------------------");
   out.push("# -------------------- Remove existing model --------------------------------------");
   out.push("wipe");
   out.push("");
@@ -19,8 +33,8 @@ function convertJsonToTcl(model) {
   out.push("# -------------------- Nodes ------------------------------------------------------");
   for (const n of (model.nodes || [])) {
     const id = n.nodeId;
-    const x = Number(n.x).toFixed(3);
-    const y = Number(n.y).toFixed(3);
+    const x = conv.length(Number(n.x), LEN_U).toFixed(3);
+    const y = conv.length(Number(n.y), LEN_U).toFixed(3);
     out.push(`node ${id} ${x} ${y}`);
   }
   out.push("");


### PR DESCRIPTION
## Summary
- ensure json2tcl assumes mm-N-sec-K base units
- convert node coordinates from model units to millimeters

## Testing
- `node -e "const {convertJsonToTcl} = require('./js/json2tcl.js'); const fs=require('fs'); const data=JSON.parse(fs.readFileSync('test/Frame_01.json','utf8')); console.log(convertJsonToTcl(data));"`


------
https://chatgpt.com/codex/tasks/task_e_68c521858074832cbfd58f0d1bb6bc01